### PR TITLE
Have dependabot PRs target develop instead of master

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,7 @@ updates:
     open-pull-requests-limit: 10
     schedule:
       interval: "daily"
+    target-branch: "develop"
     labels:
       - "documentation"
       - "dependencies"


### PR DESCRIPTION
RE: https://github.com/GPUOpen-ProfessionalCompute-Libraries/MIVisionX/pull/1194