### PR TITLE
turbojpeg library update for rocAL

### DIFF
--- a/docs/examples/image_processing/decoder.py
+++ b/docs/examples/image_processing/decoder.py
@@ -6,10 +6,10 @@ import amd.rocal.fn as fn
 import amd.rocal.types as types
 import matplotlib.gridspec as gridspec
 import matplotlib.pyplot as plt
-import cupy as cp
+#import cupy as cp
 
 seed = 1549361629
-image_dir = "../../../../data/images/AMD-tinyDataSet/"
+image_dir = "../../../data/images/AMD-tinyDataSet/"
 batch_size = 4
 gpu_id = 0
 
@@ -34,13 +34,13 @@ def show_pipeline_output(pipe, device):
     pipe.build()
     data_loader = ROCALClassificationIterator(pipe, device)
     images = next(iter(data_loader))
-    show_images(images[0], device)
+    show_images(images[0][0], device)
 
 @pipeline_def(seed=seed)
 def image_decoder_pipeline(device="cpu", path=image_dir):
-    jpegs, labels = fn.readers.file(file_root=path, shard_id=0, num_shards=1, random_shuffle=False)
-    images = fn.decoders.image(jpegs, file_root=path, device=device, output_type=types.RGB, shard_id=0, num_shards=1, random_shuffle=False)
-    return fn.resize(images, device=device, resize_x=300, resize_y=300)
+    jpegs, labels = fn.readers.file(file_root=path)
+    images = fn.decoders.image(jpegs, file_root=image_dir, device=device, output_type=types.RGB, shard_id=0, num_shards=1, random_shuffle=False)
+    return fn.resize(images, device=device, resize_width=300, resize_height=300)
 
 def main():
     print ('Optional arguments: <cpu/gpu image_folder>')
@@ -52,9 +52,8 @@ def main():
           rocal_device = "gpu"
     if  len(sys.argv) > 2:
       img_folder = sys.argv[2]
-
-    pipe = image_decoder_pipeline(batch_size=bs, num_threads=1, device_id=gpu_id, rocal_cpu=True, tensor_layout=types.NHWC,
-                                  reverse_channels=True, mean = [0, 0, 0], std=[255, 255, 255], device=rocal_device, path=img_folder)
+    pipe = image_decoder_pipeline(batch_size=bs, num_threads=1, device_id=gpu_id, rocal_cpu=True, tensor_layout=types.NHWC, 
+                                reverse_channels=True, mean = [0, 0, 0], std=[255,255,255], device=rocal_device, path=img_folder)
     show_pipeline_output(pipe, device=rocal_device)
 
 if __name__ == '__main__':

--- a/docs/examples/image_processing/decoder.py
+++ b/docs/examples/image_processing/decoder.py
@@ -6,7 +6,7 @@ import amd.rocal.fn as fn
 import amd.rocal.types as types
 import matplotlib.gridspec as gridspec
 import matplotlib.pyplot as plt
-#import cupy as cp
+import cupy as cp
 
 seed = 1549361629
 image_dir = "../../../data/images/AMD-tinyDataSet/"
@@ -39,7 +39,7 @@ def show_pipeline_output(pipe, device):
 @pipeline_def(seed=seed)
 def image_decoder_pipeline(device="cpu", path=image_dir):
     jpegs, labels = fn.readers.file(file_root=path)
-    images = fn.decoders.image(jpegs, file_root=image_dir, device=device, output_type=types.RGB, shard_id=0, num_shards=1, random_shuffle=False)
+    images = fn.decoders.image(jpegs, file_root=path, device=device, output_type=types.RGB, shard_id=0, num_shards=1, random_shuffle=False)
     return fn.resize(images, device=device, resize_width=300, resize_height=300)
 
 def main():

--- a/docs/examples/image_processing/decoder_examples.ipynb
+++ b/docs/examples/image_processing/decoder_examples.ipynb
@@ -38,7 +38,7 @@
     "%matplotlib inline\n",
     "\n",
     "seed = 1549361629\n",
-    "image_dir = \"../../../../data/images/AMD-tinyDataSet/\"\n",
+    "image_dir = \"../../../data/images/AMD-tinyDataSet/\"\n",
     "batch_size = 4\n",
     "gpu_id = 0\n",
     "\n",
@@ -61,7 +61,7 @@
     "    pipe.build()\n",
     "    data_loader = ROCALClassificationIterator(pipe, device, device_id)\n",
     "    images = next(iter(data_loader))\n",
-    "    show_images(images[0], device)\n"
+    "    show_images(images[0][0], device)\n"
    ]
   },
   {
@@ -82,9 +82,9 @@
    "source": [
     "@pipeline_def(seed=seed)\n",
     "def image_decoder_pipeline(device=\"cpu\"):\n",
-    "    jpegs, labels = fn.readers.file(file_root=image_dir, shard_id=0, num_shards=1, random_shuffle=False)\n",
+    "    jpegs, labels = fn.readers.file(file_root=image_dir)\n",
     "    images = fn.decoders.image(jpegs, file_root=image_dir, device=device, output_type=types.RGB, shard_id=0, num_shards=1, random_shuffle=False)\n",
-    "    return fn.resize(images, device=device, resize_x=300, resize_y=300)\n",
+    "    return fn.resize(images, device=device, resize_width=300, resize_height=300)\n",
     "\n",
     "pipe = image_decoder_pipeline(batch_size=batch_size, num_threads=1, device_id=gpu_id, rocal_cpu=True, tensor_layout=types.NHWC, \n",
     "                            reverse_channels=True, mean = [0, 0, 0], std=[255,255,255], device=\"cpu\")\n",
@@ -109,12 +109,13 @@
    "source": [
     "@pipeline_def(seed=seed)\n",
     "def image_decoder_random_crop_pipeline(device=\"cpu\"):\n",
-    "    jpegs, labels = fn.readers.file(file_root=image_dir, shard_id=0, num_shards=1, random_shuffle=False)\n",
+    "    jpegs, labels = fn.readers.file(file_root=image_dir)\n",
     "    images = fn.decoders.image_slice(jpegs, file_root=image_dir, \n",
-    "                                     device=device,\n",
     "                                     output_type=types.RGB,\n",
+    "                                     shard_id = 0,\n",
+    "                                     num_shards = 1,\n",
     "                                     random_shuffle=True)\n",
-    "    return fn.resize(images, device=device, resize_x=300, resize_y=300)\n",
+    "    return fn.resize(images, device=device, resize_width=300, resize_height=300)\n",
     "    \n",
     "pipe = image_decoder_random_crop_pipeline(batch_size=batch_size, num_threads=1, device_id=gpu_id, rocal_cpu=True, tensor_layout=types.NHWC, \n",
     "                                          reverse_channels=True, mean=[0,0,0], std = [255,255,255], device=\"cpu\")\n",
@@ -184,7 +185,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.10.12"
   },
   "vscode": {
    "interpreter": {

--- a/docs/examples/image_processing/inference_pipeline.py
+++ b/docs/examples/image_processing/inference_pipeline.py
@@ -31,7 +31,7 @@ import matplotlib.pyplot as plt
 
 
 seed = 1549361629
-image_dir = "../../../../data/images/AMD-tinyDataSet/"
+image_dir = "../../../data/images/AMD-tinyDataSet/"
 batch_size = 4
 gpu_id = 0
 

--- a/rocAL-setup.py
+++ b/rocAL-setup.py
@@ -337,7 +337,7 @@ else:
     os.system(
         '(cd '+deps_dir+'; git clone -b 3.0.1 https://github.com/libjpeg-turbo/libjpeg-turbo.git )')
     os.system('(cd '+deps_dir+'/libjpeg-turbo; mkdir build; cd build; '+linuxCMake +
-              ' -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=RELEASE -DENABLE_STATIC=FALSE -DCMAKE_INSTALL_DEFAULT_LIBDIR=lib ..; make -j 4; sudo make install )')
+              ' -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=RELEASE -DENABLE_STATIC=FALSE -DCMAKE_INSTALL_DEFAULT_LIBDIR=lib -DWITH_JPEG8=TRUE ..; make -j 4; sudo make install )')
     # RPP
     os.system('sudo -v')
     os.system('(cd '+deps_dir+'; git clone -b '+rppVersion+' https://github.com/GPUOpen-ProfessionalCompute-Libraries/rpp.git; cd rpp; mkdir build-'+backend+'; cd build-'+backend+'; ' +

--- a/rocAL-setup.py
+++ b/rocAL-setup.py
@@ -333,9 +333,9 @@ else:
         os.system('sudo '+linuxFlag+' '+linuxSystemInstall+' ' +
                   linuxSystemInstall_check+' install lmdb-devel rapidjson-devel')
 
-    # turbo-JPEG - https://github.com/rrawther/libjpeg-turbo.git -- 2.0.6.2
+    # turbo-JPEG - https://github.com/libjpeg-turbo/libjpeg-turbo.git -- 3.0.1
     os.system(
-        '(cd '+deps_dir+'; git clone -b 3.0.1 https://github.com/libjpeg-turbo.git )')
+        '(cd '+deps_dir+'; git clone -b 3.0.1 https://github.com/libjpeg-turbo/libjpeg-turbo.git )')
     os.system('(cd '+deps_dir+'/libjpeg-turbo; mkdir build; cd build; '+linuxCMake +
               ' -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=RELEASE -DENABLE_STATIC=FALSE -DCMAKE_INSTALL_DEFAULT_LIBDIR=lib ..; make -j 4; sudo make install )')
     # RPP

--- a/rocAL-setup.py
+++ b/rocAL-setup.py
@@ -335,7 +335,7 @@ else:
 
     # turbo-JPEG - https://github.com/rrawther/libjpeg-turbo.git -- 2.0.6.2
     os.system(
-        '(cd '+deps_dir+'; git clone -b 2.0.6.2 https://github.com/rrawther/libjpeg-turbo.git )')
+        '(cd '+deps_dir+'; git clone -b 3.0.1 https://github.com/libjpeg-turbo.git )')
     os.system('(cd '+deps_dir+'/libjpeg-turbo; mkdir build; cd build; '+linuxCMake +
               ' -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=RELEASE -DENABLE_STATIC=FALSE -DCMAKE_INSTALL_DEFAULT_LIBDIR=lib ..; make -j 4; sudo make install )')
     # RPP

--- a/rocAL/CMakeLists.txt
+++ b/rocAL/CMakeLists.txt
@@ -42,6 +42,14 @@ find_package(Threads QUIET)
 find_package(LMDB QUIET)	
 find_package(RapidJSON QUIET)
 
+if(DEFINED ENV{ROCM_PATH})
+  set(ROCM_PATH $ENV{ROCM_PATH} CACHE PATH "Default ROCm installation path")
+elseif(ROCM_PATH)
+  message("-- INFO:ROCM_PATH Set -- ${ROCM_PATH}")
+else()
+  set(ROCM_PATH /opt/rocm CACHE PATH "Default ROCm installation path")
+endif()
+
 # HIP Backend
 if(GPU_SUPPORT AND "${BACKEND}" STREQUAL "HIP")
     if(NOT DEFINED HIP_PATH)
@@ -220,6 +228,7 @@ if(${BUILD_ROCAL})
                 include/augmentations/geometry_augmentations/
                 include/decoders/image/
                 include/decoders/video/
+                include/decoders/libjpeg/
                 include/device/
                 include/loaders/
                 include/loaders/image/

--- a/rocAL/include/decoders/image/fused_crop_decoder.h
+++ b/rocAL/include/decoders/image/fused_crop_decoder.h
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2019 - 2023 Advanced Micro Devices, Inc. All rights reserved.
+Copyright (c) 2019 - 2024 Advanced Micro Devices, Inc. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/rocAL/include/decoders/image/turbo_jpeg_decoder.h
+++ b/rocAL/include/decoders/image/turbo_jpeg_decoder.h
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2019 - 2023 Advanced Micro Devices, Inc. All rights reserved.
+Copyright (c) 2019 - 2024 Advanced Micro Devices, Inc. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -64,24 +64,8 @@ class TJDecoder : public Decoder {
 
    private:
     tjhandle m_jpegDecompressor;
-    const static unsigned SCALING_FACTORS_COUNT = 16;
-    const tjscalingfactor SCALING_FACTORS[SCALING_FACTORS_COUNT] = {
-        {2, 1},
-        {15, 8},
-        {7, 4},
-        {13, 8},
-        {3, 2},
-        {11, 8},
-        {5, 4},
-        {9, 8},
-        {1, 1},
-        {7, 8},
-        {3, 4},
-        {5, 8},
-        {1, 2},
-        {3, 8},
-        {1, 4},
-        {1, 8}};
+    tjscalingfactor *_scaling_factors = nullptr;
+    int _num_scaling_factors = 0;
     bool _is_partial_decoder = false;
     std::vector<float> _bbox_coord;
     const static unsigned _max_scaling_factor = 8;

--- a/rocAL/include/decoders/libjpeg/libjpeg_extra.h
+++ b/rocAL/include/decoders/libjpeg/libjpeg_extra.h
@@ -1,0 +1,75 @@
+/*
+Copyright (c) 2019 - 2024 Advanced Micro Devices, Inc. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+#pragma once
+
+#include <turbojpeg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <ctype.h>
+#include "libjpeg_utils.h"
+
+extern "C" {
+
+//! extra apis for rocal to support partial decoding
+
+//! * Helper function to se the source
+//! * This function doesn't scale the decoded image
+
+//! * Decompress a subregion of JPEG image to an RGB, grayscale, or CMYK image.
+//! * This function doesn't scale the decoded image
+
+/*!
+  \param handle  TJPeg handle
+  \param jpegBuf compressed jpeg image buffer
+  \param jpegSize Size of the compressed data provided in the input_buffer
+  \param dstBuf user provided output buffer
+  \param width, pitch, height  width, stride and height of the allocated buffer
+  \param flags  TJPEG flags
+  \param pixelFormat  pixel format of the image
+  \param crop_x_diff,  crop_width_diff Actual crop_x and crop_w (adjusted to MB boundery)
+  \param x1, y1, crop_width, crop_height requested crop window
+*/
+
+int tjDecompress2_partial(tjhandle handle, const unsigned char *jpegBuf,
+                                    unsigned long jpegSize, unsigned char *dstBuf,
+                                    int width, int pitch, int height, int pixelFormat,
+                                    int flags, unsigned int *crop_x_diff, unsigned int *crop_width_diff,
+                                    unsigned int x1, unsigned int y1, unsigned int crop_width, unsigned int crop_height);
+
+
+//! * Decompress a subregion of JPEG image to an RGB, grayscale, or CMYK image.
+//! * This function scale the decoded image to fit the output dims
+/*!
+  \param handle  TJPeg handle
+  \param jpegBuf compressed jpeg image buffer
+  \param jpegSize Size of the compressed data provided in the input_buffer
+  \param dstBuf user provided output buffer
+  \param width, pitch, height  width, stride and height of the allocated buffer
+  \param flags  TJPEG flags
+  \param crop_width, crop_height requested crop window
+*/
+
+int tjDecompress2_partial_scale(tjhandle handle, const unsigned char *jpegBuf,
+                            unsigned long jpegSize, unsigned char *dstBuf,
+                            int width, int pitch, int height, int pixelFormat,
+                            int flags, unsigned int crop_width, unsigned int crop_height);
+}

--- a/rocAL/include/decoders/libjpeg/libjpeg_utils.h
+++ b/rocAL/include/decoders/libjpeg/libjpeg_utils.h
@@ -1,0 +1,30 @@
+/*
+Copyright (c) 2019 - 2024 Advanced Micro Devices, Inc. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+#pragma once
+
+//! turbojpeg includes
+
+extern "C" {
+#include "jerror.h"  
+#include "jpeglib.h" 
+#include "jpegint.h"
+}

--- a/rocAL/include/loaders/image/image_read_and_decode.h
+++ b/rocAL/include/loaders/image/image_read_and_decode.h
@@ -33,14 +33,6 @@ THE SOFTWARE.
 #include "timing_debug.h"
 #include "turbo_jpeg_decoder.h"
 
-/**
- * Compute the scaled value of <tt>dimension</tt> using the given scaling
- * factor.  This macro performs the integer equivalent of <tt>ceil(dimension *
- * scalingFactor)</tt>.
- */
-#define TJSCALED(dimension, scalingFactor)                       \
-    ((dimension * scalingFactor.num + scalingFactor.denom - 1) / \
-     scalingFactor.denom)
 
 class ImageReadAndDecode {
    public:

--- a/rocAL/source/decoders/image/fused_crop_decoder.cpp
+++ b/rocAL/source/decoders/image/fused_crop_decoder.cpp
@@ -20,11 +20,13 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-#include "fused_crop_decoder.h"
 
 #include <commons.h>
 #include <stdio.h>
 #include <string.h>
+#include "fused_crop_decoder.h"
+#include "libjpeg_extra.h"
+
 
 FusedCropTJDecoder::FusedCropTJDecoder() {
     m_jpegDecompressor = tjInitDecompress();

--- a/rocAL/source/decoders/libjpeg/libjpeg_extra.cpp
+++ b/rocAL/source/decoders/libjpeg/libjpeg_extra.cpp
@@ -1,0 +1,282 @@
+/*
+Copyright (c) 2019 - 2024 Advanced Micro Devices, Inc. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of inst software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and inst permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#include "libjpeg_extra.h"
+#include <setjmp.h>
+#include <string.h>
+#include "commons.h"
+
+enum { COMPRESS = 1, DECOMPRESS = 2 };
+static J_COLOR_SPACE pf2cs[TJ_NUMPF] = {
+  JCS_EXT_RGB, JCS_EXT_BGR, JCS_EXT_RGBX, JCS_EXT_BGRX, JCS_EXT_XBGR,
+  JCS_EXT_XRGB, JCS_GRAYSCALE, JCS_EXT_RGBA, JCS_EXT_BGRA, JCS_EXT_ABGR,
+  JCS_EXT_ARGB, JCS_CMYK
+};
+
+struct my_error_mgr {
+  struct jpeg_error_mgr pub;
+  jmp_buf setjmp_buffer;
+  void (*emit_message) (j_common_ptr, int);
+  boolean warning, stopOnWarning;
+};
+typedef struct my_error_mgr *my_error_ptr;
+
+/*
+ * Here's the routine that will replace the standard error_exit method:
+ */
+
+METHODDEF(void)
+my_error_exit(j_common_ptr cinfo)
+{
+  /* cinfo->err really points to a my_error_mgr struct, so coerce pointer */
+  my_error_ptr myerr = (my_error_ptr)cinfo->err;
+
+  /* Always display the message. */
+  /* We could postpone this until after returning, if we chose. */
+  (*cinfo->err->output_message) (cinfo);
+
+  /* Return control to the setjmp point */
+  longjmp(myerr->setjmp_buffer, 1);
+}
+
+
+//! * Decompress a subregion of JPEG image to an RGB, grayscale, or CMYK image.
+//! * inst function doesn't scale the decoded image
+int tjDecompress2_partial(tjhandle handle, const unsigned char *jpegBuf,
+                                    unsigned long jpegSize, unsigned char *dstBuf,
+                                    int width, int pitch, int height, int pixelFormat,
+                                    int flags, unsigned int *crop_x_diff, unsigned int *crop_width_diff,
+                                    unsigned int crop_x, unsigned int crop_y,
+                                    unsigned int crop_width, unsigned int crop_height)
+{
+    JSAMPROW *row_pointer = NULL;
+    int i, retval = 0;
+    int64_t total_size;
+
+    if (jpegBuf == NULL || jpegSize <= 0 || dstBuf == NULL || width < 0 ||
+        pitch < 0 || height < 0 || pixelFormat < 0 || pixelFormat >= TJ_NUMPF)
+        THROW("tjDecompress2_partial(): Invalid argument");
+
+    struct jpeg_decompress_struct cinfo;
+    // Initialize libjpeg structures to have a memory source
+    // Modify the usual jpeg error manager to catch fatal errors.
+    struct my_error_mgr jerr;
+    cinfo.err = jpeg_std_error(&jerr.pub);
+    jerr.pub.error_exit = my_error_exit;
+    if (setjmp(jerr.setjmp_buffer)) {
+      /* If we get here, the JPEG code has signaled an error. */
+      retval = -1;  goto bailout;
+    }
+
+    // set up, read header, set image parameters, save size
+    jpeg_create_decompress(&cinfo);
+    jpeg_mem_src(&cinfo, jpegBuf, jpegSize);
+    jpeg_read_header(&cinfo, TRUE);
+    cinfo.out_color_space = pf2cs[pixelFormat];
+    if (flags & TJFLAG_FASTDCT) cinfo.dct_method = JDCT_FASTEST;
+    if (flags & TJFLAG_FASTUPSAMPLE) cinfo.do_fancy_upsampling = FALSE;
+    
+    // Determine the output image size before attempting decompress to prevent
+    // OOM'ing doing the decompress
+    jpeg_calc_output_dimensions(&cinfo);
+
+    total_size = static_cast<int64_t>(cinfo.output_height) * 
+                        static_cast<int64_t>(cinfo.output_width) *
+                        static_cast<int64_t>(cinfo.num_components);
+    // Some of the internal routines do not gracefully handle ridiculously
+    // large images, so fail fast.
+    if (cinfo.output_width <= 0 || cinfo.output_height <= 0) {
+        ERR ("Invalid image size: " << cinfo.output_width << " x " << cinfo.output_height);
+        retval = -1;  goto bailout;
+    }
+    if (total_size >= (1LL << 29)) {
+        ERR("Image too large: " << total_size);
+        retval = -1;  goto bailout;
+    }
+
+    jpeg_start_decompress(&cinfo);
+
+    /* Check for valid crop dimensions.  We cannot check these values until
+    * after jpeg_start_decompress() is called.
+    */
+    if (crop_x + crop_width > cinfo.output_width || crop_y + crop_height > cinfo.output_height) {
+        ERR("crop dimensions:" << crop_width << " x " << crop_height << " exceed image dimensions" <<
+            cinfo.output_width << " x " << cinfo.output_height);
+        retval = -1;  goto bailout;
+    }
+
+    jpeg_crop_scanline(&cinfo, &crop_x, &crop_width);
+    *crop_x_diff = crop_x;
+    *crop_width_diff = crop_width;
+
+    if (pitch == 0) pitch = cinfo.output_width * tjPixelSize[pixelFormat];
+
+    if ((row_pointer = (JSAMPROW *)malloc(sizeof(JSAMPROW) * cinfo.output_height)) == NULL) {
+      THROW("tjDecompress2_partial(): Memory allocation failure");
+      if (setjmp(jerr.setjmp_buffer)) {
+          /* If we get here, the JPEG code has signaled an error. */
+          retval = -1;  goto bailout;
+      }
+    }
+    
+    // set row pointer for destination
+    for (i = 0; i < (int)cinfo.output_height; i++) {
+      if (flags & TJFLAG_BOTTOMUP)
+        row_pointer[i] = &dstBuf[(cinfo.output_height - i - 1) * (size_t)pitch];
+      else
+        row_pointer[i] = &dstBuf[i * (size_t)pitch];
+    }
+
+    /* Process data */
+    JDIMENSION num_scanlines;
+    jpeg_skip_scanlines(&cinfo, crop_y);
+    while (cinfo.output_scanline <  crop_y + crop_height) {
+        num_scanlines = jpeg_read_scanlines(&cinfo,  &row_pointer[cinfo.output_scanline],
+                                        crop_y + crop_height - cinfo.output_scanline);
+        if (num_scanlines == 0){
+          ERR("Premature end of Jpeg data. Stopped at " << cinfo.output_scanline - crop_y << "/"
+              << cinfo.output_height)
+        }
+    }
+    jpeg_skip_scanlines(&cinfo, cinfo.output_height - crop_y - crop_height);
+    jpeg_finish_decompress(&cinfo);
+
+    bailout:
+    if (cinfo.global_state > DSTATE_START) jpeg_abort_decompress(&cinfo);
+    if (row_pointer) free(row_pointer);
+    return retval;
+}
+
+//! * Decompress a subregion of JPEG image to an RGB, grayscale, or CMYK image.
+//! * inst function scale the decoded image to fit the output dims
+
+int tjDecompress2_partial_scale(tjhandle handle, const unsigned char *jpegBuf,
+                            unsigned long jpegSize, unsigned char *dstBuf,
+                            int width, int pitch, int height, int pixelFormat,
+                            int flags, unsigned int crop_width, unsigned int crop_height)
+{
+    JSAMPROW *row_pointer = NULL;
+    int i, retval = 0, jpegwidth, jpegheight;
+    unsigned int scaledw, scaledh, crop_x, crop_y, max_crop_width;
+    tjscalingfactor *scalingFactors = NULL;
+    int numScalingFactors = 0;
+
+    unsigned char *tmp_row = NULL;
+    if (jpegBuf == NULL || jpegSize <= 0 || dstBuf == NULL || width < 0 || 
+          pitch < 0 || height < 0 || pixelFormat < 0 || pixelFormat >= TJ_NUMPF) {
+        THROW("tjDecompress2_partial_scale(): Invalid argument");
+    }
+
+    struct jpeg_decompress_struct cinfo;
+    // Initialize libjpeg structures to have a memory source
+    // Modify the usual jpeg error manager to catch fatal errors.
+    struct my_error_mgr jerr;
+    cinfo.err = jpeg_std_error(&jerr.pub);
+    jerr.pub.error_exit = my_error_exit;
+    if (setjmp(jerr.setjmp_buffer)) {
+        /* If we get here, the JPEG code has signaled an error. */
+        retval = -1;  goto bailout;
+    }
+
+    jpeg_mem_src(&cinfo, jpegBuf, jpegSize);
+    jpeg_read_header(&cinfo, TRUE);
+    cinfo.out_color_space = pf2cs[pixelFormat];
+    if (flags & TJFLAG_FASTDCT) cinfo.dct_method = JDCT_FASTEST;
+    if (flags & TJFLAG_FASTUPSAMPLE) cinfo.do_fancy_upsampling = FALSE;
+
+    jpegwidth = cinfo.image_width;  jpegheight = cinfo.image_height;
+    if (width == 0) width = jpegwidth;
+    if (height == 0) height = jpegheight;
+    if ((scalingFactors = tj3GetScalingFactors(&numScalingFactors)) == NULL)
+        THROW("tjDecompress2_partial_scale(): error getting scaling factors");
+
+    for (i = 0; i < numScalingFactors; i++) {
+      scaledw = TJSCALED(crop_width, scalingFactors[i]);
+      scaledh = TJSCALED(crop_height, scalingFactors[i]);
+      if (scaledw <= (unsigned int)width && scaledh <= (unsigned int)height)
+        break;
+    }
+
+    if (i >= numScalingFactors)
+      THROW("tjDecompress2_partial_scale(): Could not scale down to desired image dimensions");
+    
+    if (cinfo.num_components > 3)
+      THROW("tjDecompress2_partial_scale(): JPEG image must have 3 or fewer components");
+    
+    //width = scaledw;  height = scaledh;
+    cinfo.scale_num = scalingFactors[i].num;
+    cinfo.scale_denom = scalingFactors[i].denom;
+
+    jpeg_start_decompress(&cinfo);
+    crop_x = cinfo.output_width - scaledw;
+    crop_y = cinfo.output_height - scaledh;
+
+    /* Check for valid crop dimensions.  We cannot check these values until
+    * after jpeg_start_decompress() is called.
+    */
+    if (crop_x + scaledw   > cinfo.output_width || scaledh   > cinfo.output_height) {
+        ERR("crop dimensions:" << crop_x + scaledw << " x " << scaledh << " exceed image dimensions" <<
+            cinfo.output_width << " x " << cinfo.output_height);
+        retval = -1;  goto bailout;
+    }
+
+    if (pitch == 0) pitch = cinfo.output_width * tjPixelSize[pixelFormat];
+
+    if ((row_pointer =
+        (JSAMPROW *)malloc(sizeof(JSAMPROW) * cinfo.output_height)) == NULL)
+        THROW("tjDecompress2_partial_scale(): Memory allocation failure");
+    // allocate row of tmp storage for storing discarded data
+    tmp_row = (unsigned char *)malloc((size_t)pitch);
+
+    if (setjmp(jerr.setjmp_buffer)) {
+      /* If we get here, the JPEG code has signaled an error. */
+      retval = -1;  goto bailout;
+    }
+
+    for (i = 0; i < (int)cinfo.output_height; i++) {
+        if (i < height) {
+            if (flags & TJFLAG_BOTTOMUP)
+                row_pointer[i] = &dstBuf[(cinfo.output_height - i - 1) * (size_t)pitch];
+            else
+                row_pointer[i] = &dstBuf[i * (size_t)pitch];
+        } else {
+            row_pointer[i] = tmp_row;
+        }
+    }
+    // the width for the crop shouln't exceed output_width
+    max_crop_width = scaledw;
+    jpeg_crop_scanline(&cinfo, &crop_x, &max_crop_width);
+    jpeg_skip_scanlines(&cinfo, crop_y);
+    while (cinfo.output_scanline <  cinfo.output_height) {
+      if (cinfo.output_scanline < crop_y)
+          jpeg_read_scanlines(&cinfo,  &row_pointer[cinfo.output_scanline], cinfo.output_height - cinfo.output_scanline);
+      else
+          jpeg_read_scanlines(&cinfo,  &row_pointer[cinfo.output_scanline- crop_y], cinfo.output_height - cinfo.output_scanline);
+    }
+    jpeg_finish_decompress(&cinfo);
+
+  bailout:
+    if (cinfo.global_state > DSTATE_START) jpeg_abort_decompress(&cinfo);
+    if (row_pointer) free(row_pointer);
+    if (tmp_row) free(tmp_row);
+    return retval;
+}

--- a/rocAL_pybind/setup.py
+++ b/rocAL_pybind/setup.py
@@ -36,7 +36,7 @@ class BinaryDistribution(Distribution):
 setup(
     name='amd-rocal',
     description='AMD ROCm Augmentation Library',
-    url='https://github.com/GPUOpen-ProfessionalCompute-Libraries/MIVisionX/rocAL',
+    url='https://github.com/ROCm/rocAL',
     version='1.0.0',
     author='AMD',
     license='Apache License 2.0',


### PR DESCRIPTION
Removes private branch for turbojpeg.
Upgraded turbojpeg to public branch 3.0.1.
Need to re-run setup script for the changes to take effect