### PR TITLE
Update commands and dependencies for CI

### DIFF
--- a/.jenkins/common.groovy
+++ b/.jenkins/common.groovy
@@ -24,7 +24,7 @@ def runCompileCommand(platform, project, jobName, boolean debug=false, boolean s
     }
 
     def command = """#!/usr/bin/env bash
-                set -x
+                set -ex
                 ${enableSCL}
                 echo Build rocAL - ${buildTypeDir}
                 cd ${project.paths.project_build_prefix}
@@ -44,7 +44,7 @@ def runCompileCommand(platform, project, jobName, boolean debug=false, boolean s
 def runTestCommand (platform, project) {
 
     def command = """#!/usr/bin/env bash
-                set -x
+                set -ex
                 export HOME=/home/jenkins
                 echo Make Test
                 cd ${project.paths.project_build_prefix}/build/release
@@ -100,7 +100,7 @@ def runPackageCommand(platform, project) {
     }
 
     def command = """#!/usr/bin/env bash
-                set -x
+                set -ex
                 export HOME=/home/jenkins
                 echo Make rocal Package
                 cd ${project.paths.project_build_prefix}/build/release

--- a/.jenkins/precheckin.groovy
+++ b/.jenkins/precheckin.groovy
@@ -9,6 +9,8 @@ def runCI =
     
     def prj = new rocProject('rocAL', 'PreCheckin')
 
+    prj.libraryDependencies = ['rpp','MIVisionX']
+
     def nodes = new dockerNodes(nodeDetails, jobName, prj)
 
     def commonGroovy


### PR DESCRIPTION
Exit CI if stage (eg: docker, compile, package, test) fails, to avoid incorrectly passing the stage if an error is thrown


Add MIVisionX and rpp as dependencies (re: FindAMDRPP.cmake and FindMIVisionX.cmake)