### PR TITLE
CPU Build Fix

### DIFF
--- a/rocAL/source/augmentations/geometry_augmentations/node_crop.cpp
+++ b/rocAL/source/augmentations/geometry_augmentations/node_crop.cpp
@@ -21,6 +21,7 @@ THE SOFTWARE.
 */
 
 #include <vx_ext_rpp.h>
+#include <vx_ext_amd.h>
 #include <graph.h>
 #include "node_crop.h"
 #include "parameter_crop.h"


### PR DESCRIPTION
Without including vx_ext_amd.h header file, the rocal build fails with the following error on the develop branch: 
```
rocAL/source/augmentations/geometry_augmentations/node_crop.cpp:111:20: error: ‘VX_MEMORY_TYPE_HIP’ was not declared in this scope; did you mean ‘VX_MEMORY_TYPE_HOST’?
  111 |         mem_type = VX_MEMORY_TYPE_HIP;
      |                    ^~~~~~~~~~~~~~~~~~
      |                    VX_MEMORY_TYPE_HOST
```
