### PR TITLE
Include Fix for CPU Backend

### DIFF
--- a/rocAL/source/pipeline/tensor.cpp
+++ b/rocAL/source/pipeline/tensor.cpp
@@ -22,7 +22,7 @@ THE SOFTWARE.
 */
 
 #include <cstdio>
-#if !ENABLE_HIP
+#if ENABLE_OPENCL
 #include <CL/cl.h>
 #endif
 #include <vx_ext_amd.h>


### PR DESCRIPTION
Including cl.h file in the cpu backend fails when opencl is not installed. 
Added a fix to address this issue.