### PR TITLE
removing undefined functions

### DIFF
--- a/rocAL_pybind/amd/rocal/pipeline.py
+++ b/rocAL_pybind/amd/rocal/pipeline.py
@@ -26,7 +26,7 @@
 import rocal_pybind as b
 import amd.rocal.types as types
 import numpy as np
-import cupy as cp
+#import cupy as cp
 import ctypes
 import functools
 import inspect
@@ -153,6 +153,8 @@ class Pipeline(object):
         b.rocalToTensor(self._handle, ctypes.c_void_p(array.data_ptr()), tensor_format, tensor_dtype,
                         multiplier[0], multiplier[1], multiplier[2], offset[0], offset[1], offset[2], (1 if reverse_channels else 0), self._output_memory_type, max_roi_height, max_roi_width)
 
+    """
+    NOTE: getOneHotEncodedLabels is not defined. This function does not have a cpp equivalent. Bring back once cupy/fucntion is fixed
     def get_one_hot_encoded_labels(self, array, device):
         if device == "cpu":
             if (isinstance(array, np.ndarray)):
@@ -166,7 +168,7 @@ class Pipeline(object):
                     self._handle, array.data.ptr, self._num_classes, 1)
             else:  # torch tensor
                 return b.getOneHotEncodedLabels(self._handle, ctypes.c_void_p(array.data_ptr()), self._num_classes, 1)
-
+    """
     def set_outputs(self, *output_list):
         b.setOutputs(self._handle, len(output_list), output_list)
 


### PR DESCRIPTION
Commenting out `get_one_hot_encoded_labels` from pipeline.py.
This function `b.getOneHotEncodedLabels` is not defined in rocal_pybind.cpp.
Also removes cupy requirement from Pipeline.
@swetha097 We need to discuss this offline
