### PR TITLE
CMakeLists.txt update to remove unnecessary variable - develop

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,8 +132,11 @@ if(AMD_FP16_SUPPORT)
 endif(AMD_FP16_SUPPORT)
 
 add_subdirectory(rocAL)
-add_subdirectory(rocAL_pybind)
-
+if(BUILD_PYPACKAGE)
+  add_subdirectory(rocAL_pybind)
+else()
+  message("-- ${Cyan}ROCAL Python Module turned OFF by user option -D BUILD_PYPACKAGE=OFF ${ColourReset}")
+endif()
 # install rocAL docs -- {ROCM_PATH}/${CMAKE_INSTALL_DATADIR}/doc/rocal/
 install(FILES docs/README.md DESTINATION ${CMAKE_INSTALL_DATADIR}/doc/rocal)
 

--- a/cmake/FindMIVisionX.cmake
+++ b/cmake/FindMIVisionX.cmake
@@ -64,19 +64,6 @@ find_library(VXRPP_LIBRARIES
 )
 mark_as_advanced(VXRPP_LIBRARIES)
 
-find_path(MIVisionX_LIBRARIES_DIRS
-    NAMES libopenvx${SHARED_LIB_TYPE}
-    HINTS
-    $ENV{ROCM_PATH}/lib
-    $ENV{ROCM_PATH}/lib64
-    $ENV{MIVisionX_PATH}/lib
-    PATHS
-    ${MIVisionX_PATH}/lib
-    /usr/lib
-    ${ROCM_PATH}/lib
-)
-mark_as_advanced(MIVisionX_LIBRARIES_DIRS)
-
 if(OPENVX_LIBRARIES AND MIVisionX_INCLUDE_DIRS)
     set(MIVisionX_FOUND TRUE)
 endif( )
@@ -88,14 +75,12 @@ find_package_handle_standard_args( MIVisionX
         OPENVX_LIBRARIES
         VXRPP_LIBRARIES  
         MIVisionX_INCLUDE_DIRS
-        MIVisionX_LIBRARIES_DIRS
 )
 
 set(MIVisionX_FOUND ${MIVisionX_FOUND} CACHE INTERNAL "")
 set(OPENVX_LIBRARIES ${OPENVX_LIBRARIES} CACHE INTERNAL "")
 set(VXRPP_LIBRARIES ${VXRPP_LIBRARIES} CACHE INTERNAL "")
 set(MIVisionX_INCLUDE_DIRS ${MIVisionX_INCLUDE_DIRS} CACHE INTERNAL "")
-set(MIVisionX_LIBRARIES_DIRS ${MIVisionX_LIBRARIES_DIRS} CACHE INTERNAL "")
 
 if(MIVisionX_FOUND)
     message("-- ${White}Using MIVisionX -- \n\tLibraries:${OPENVX_LIBRARIES} \n\tIncludes:${MIVisionX_INCLUDE_DIRS}${ColourReset}")    

--- a/rocAL_pybind/CMakeLists.txt
+++ b/rocAL_pybind/CMakeLists.txt
@@ -22,7 +22,6 @@ cmake_minimum_required(VERSION 3.5)
 project(rocAL_pybind)
 
 set(TARGET_NAME rocAL_pybind)
-option(BUILD_PYPACKAGE  "Build rocAL Python Package" ON)
 
 set(CMAKE_INSTALL_LIBDIR "lib" CACHE STRING "Library install directory")
 include(GNUInstallDirs)
@@ -36,7 +35,6 @@ set(ROCM_PATH /opt/rocm CACHE PATH "Deafult ROCm Installation Path")
 
 set(CMAKE_CXX_STANDARD 17)
 set(BUILD_ROCAL_PYBIND true)
-set(ROCAL_PYTHON ON)
 
 find_package(AMDRPP QUIET)
 find_package(MIVisionX QUIET)


### PR DESCRIPTION
Remove unnecessary variable : MIVisionX_LIBRARIES_DIRS
Update rocAL CMake to exclude rocAL_pybind subdirectory if manually turned off