### PR TITLE
rocAL - Parameter changes

### DIFF
--- a/rocAL/include/parameters/parameter.h
+++ b/rocAL/include/parameters/parameter.h
@@ -36,7 +36,7 @@ class Parameter {
     /// allocates memory for the array with specified size
     virtual void create_array(unsigned size){};
 
-    /// used to fetch the values of the array
+    /// used to fetch the updated param values
     virtual std::vector<T> get_array() { return {}; };
 
     virtual ~Parameter() {}

--- a/rocAL/include/parameters/parameter.h
+++ b/rocAL/include/parameters/parameter.h
@@ -33,8 +33,10 @@ class Parameter {
     /// used to internally renew state of the parameter if needed (for random parameters)
     virtual void renew(){};
 
-    virtual void create_array(unsigned batch_size){};
+    /// allocates memory for the array with specified size
+    virtual void create_array(unsigned size){};
 
+    /// used to fetch the values of the array
     virtual std::vector<T> get_array() { return {}; };
 
     virtual ~Parameter() {}

--- a/rocAL/include/parameters/parameter.h
+++ b/rocAL/include/parameters/parameter.h
@@ -33,6 +33,10 @@ class Parameter {
     /// used to internally renew state of the parameter if needed (for random parameters)
     virtual void renew(){};
 
+    virtual void create_array(unsigned batch_size){};
+
+    virtual std::vector<T> get_array() { return {}; };
+
     virtual ~Parameter() {}
     ///
     /// \return returns if this parameter takes a single value (vs a range of values or many values)

--- a/rocAL/include/parameters/parameter_factory.h
+++ b/rocAL/include/parameters/parameter_factory.h
@@ -29,6 +29,8 @@ THE SOFTWARE.
 #include "parameter_random.h"
 #include "parameter_simple.h"
 
+const int MAX_SEEDS = 1024;
+
 enum class RocalParameterType {
     DETERMINISTIC = 0,
     RANDOM_UNIFORM,
@@ -72,6 +74,8 @@ class ParameterFactory {
     void set_seed(unsigned seed);
     unsigned get_seed();
     void generate_seed();
+    int64_t get_seed_from_seedsequence();
+    void increment_seed_sequence_idx();
 
     template <typename T>
     Parameter<T>* create_uniform_rand_param(T start, T end) {
@@ -104,4 +108,6 @@ class ParameterFactory {
     static ParameterFactory* _instance;
     static std::mutex _mutex;
     ParameterFactory();
+    std::vector<int64_t> _seed_vector;
+    int _seed_sequence_idx = 0;
 };

--- a/rocAL/include/parameters/parameter_factory.h
+++ b/rocAL/include/parameters/parameter_factory.h
@@ -75,7 +75,6 @@ class ParameterFactory {
     unsigned get_seed();
     void generate_seed();
     int64_t get_seed_from_seedsequence();
-    void increment_seed_sequence_idx();
 
     template <typename T>
     Parameter<T>* create_uniform_rand_param(T start, T end) {

--- a/rocAL/include/parameters/parameter_random.h
+++ b/rocAL/include/parameters/parameter_random.h
@@ -53,7 +53,7 @@ class UniformRand : public Parameter<T> {
     };
 
     std::vector<T> get_array() override {
-        return _values;
+        return _param_values;
     }
 
     void renew_value() {
@@ -73,12 +73,12 @@ class UniformRand : public Parameter<T> {
     void renew_array() {
         for (uint i = 0; i < _size; i++) {
             renew_value();
-            _values[i] = _updated_val;
+            _param_values[i] = _updated_val;
         }
     }
 
     void renew() override {
-        if (_values.size()) {
+        if (_param_values.size()) {
             renew_array();
         } else {
             renew_value();
@@ -95,8 +95,8 @@ class UniformRand : public Parameter<T> {
     }
 
     void create_array(unsigned vector_size) override {
-        if (_values.size() == 0) {
-            _values.resize(vector_size);
+        if (_param_values.size() == 0) {
+            _param_values.resize(vector_size);
             _size = vector_size;
         }
     }
@@ -109,7 +109,7 @@ class UniformRand : public Parameter<T> {
     T _start;
     T _end;
     T _updated_val;
-    std::vector<T> _values;
+    std::vector<T> _param_values;
     std::mt19937 _generator;
     std::mutex _lock;
     unsigned _size;
@@ -196,7 +196,7 @@ struct CustomRand : public Parameter<T> {
     void renew_array() {
         for (uint i = 0; i < _size; i++) {
             renew_value();
-            _values[i] = _updated_val;
+            _param_values[i] = _updated_val;
         }
     }
 
@@ -212,12 +212,12 @@ struct CustomRand : public Parameter<T> {
     };
 
     std::vector<T> get_array() override {
-        return _values;
+        return _param_values;
     }
 
     void create_array(unsigned vector_size) override {
-        if (_values.size() == 0) {
-            _values.resize(vector_size);
+        if (_param_values.size() == 0) {
+            _param_values.resize(vector_size);
             _size = vector_size;
         }
     }
@@ -232,7 +232,7 @@ struct CustomRand : public Parameter<T> {
     std::vector<double> _comltv_dist;  //!< commulative probabilities
     double _mean;
     T _updated_val;
-    std::vector<T> _values; //!< The values will be used in parameter_vx.h file after renewing
+    std::vector<T> _param_values; //!< The values will be used in parameter_vx.h file after renewing
     std::mt19937 _generator;
     std::mutex _lock;
     unsigned _size;

--- a/rocAL/include/parameters/parameter_random.h
+++ b/rocAL/include/parameters/parameter_random.h
@@ -232,7 +232,7 @@ struct CustomRand : public Parameter<T> {
     std::vector<double> _comltv_dist;  //!< commulative probabilities
     double _mean;
     T _updated_val;
-    std::vector<T> _param_values; //!< The values will be used in parameter_vx.h file after renewing
+    std::vector<T> _param_values;  //!< The values will be used in parameter_vx.h file after renewing
     std::mt19937 _generator;
     std::mutex _lock;
     unsigned _size;

--- a/rocAL/include/parameters/parameter_random.h
+++ b/rocAL/include/parameters/parameter_random.h
@@ -53,7 +53,7 @@ class UniformRand : public Parameter<T> {
     };
 
     std::vector<T> get_array() override {
-        return _elements;
+        return _values;
     }
 
     void renew_value() {
@@ -71,14 +71,14 @@ class UniformRand : public Parameter<T> {
     }
 
     void renew_array() {
-        for (uint i = 0; i < _batch_size; i++) {
+        for (uint i = 0; i < _size; i++) {
             renew_value();
-            _elements[i] = _updated_val;
+            _values[i] = _updated_val;
         }
     }
 
     void renew() override {
-        if (_elements.size()) {
+        if (_values.size()) {
             renew_array();
         } else {
             renew_value();
@@ -94,10 +94,11 @@ class UniformRand : public Parameter<T> {
         return 0;
     }
 
-    void create_array(unsigned size) override {
-        if (_elements.size() == 0)
-            _elements.resize(size);
-        _batch_size = size;
+    void create_array(unsigned vector_size) override {
+        if (_values.size() == 0) {
+            _values.resize(vector_size);
+            _size = vector_size;
+        }
     }
 
     bool single_value() const override {
@@ -108,10 +109,10 @@ class UniformRand : public Parameter<T> {
     T _start;
     T _end;
     T _updated_val;
-    std::vector<T> _elements;
+    std::vector<T> _values;
     std::mt19937 _generator;
     std::mutex _lock;
-    unsigned _batch_size;
+    unsigned _size;
 };
 
 template <typename T>
@@ -193,14 +194,14 @@ struct CustomRand : public Parameter<T> {
     }
 
     void renew_array() {
-        for (uint i = 0; i < _batch_size; i++) {
+        for (uint i = 0; i < _size; i++) {
             renew_value();
-            _elements[i] = _updated_val;
+            _values[i] = _updated_val;
         }
     }
 
     void renew() override {
-        if (_elements.size()) {
+        if (_values.size()) {
             renew_array();
         } else {
             renew_value();
@@ -211,13 +212,14 @@ struct CustomRand : public Parameter<T> {
     };
 
     std::vector<T> get_array() override {
-        return _elements;
+        return _values;
     }
 
-    void create_array(unsigned size) override {
-        if (_elements.size() == 0)
-            _elements.resize(size);
-        _batch_size = size;
+    void create_array(unsigned vector_size) override {
+        if (_values.size() == 0) {
+            _values.resize(vector_size);
+            _size = vector_size;
+        }
     }
 
     bool single_value() const override {
@@ -230,8 +232,8 @@ struct CustomRand : public Parameter<T> {
     std::vector<double> _comltv_dist;  //!< commulative probabilities
     double _mean;
     T _updated_val;
-    std::vector<T> _elements;
+    std::vector<T> _values; //!< The values will be used in parameter_vx.h file after renewing
     std::mt19937 _generator;
     std::mutex _lock;
-    unsigned _batch_size;
+    unsigned _size;
 };

--- a/rocAL/include/parameters/parameter_random.h
+++ b/rocAL/include/parameters/parameter_random.h
@@ -201,7 +201,7 @@ struct CustomRand : public Parameter<T> {
     }
 
     void renew() override {
-        if (_values.size()) {
+        if (_param_values.size()) {
             renew_array();
         } else {
             renew_value();

--- a/rocAL/include/parameters/parameter_random.h
+++ b/rocAL/include/parameters/parameter_random.h
@@ -53,7 +53,7 @@ class UniformRand : public Parameter<T> {
     };
 
     std::vector<T> get_array() override {
-        return _array;
+        return _elements;
     }
 
     void renew_value() {
@@ -73,12 +73,12 @@ class UniformRand : public Parameter<T> {
     void renew_array() {
         for (uint i = 0; i < _batch_size; i++) {
             renew_value();
-            _array[i] = _updated_val;
+            _elements[i] = _updated_val;
         }
     }
 
     void renew() override {
-        if (_array.size() > 0) {
+        if (_elements.size()) {
             renew_array();
         } else {
             renew_value();
@@ -94,10 +94,10 @@ class UniformRand : public Parameter<T> {
         return 0;
     }
 
-    void create_array(unsigned batch_size) override {
-        if (_array.size() == 0)
-            _array.resize(batch_size);
-        _batch_size = batch_size;
+    void create_array(unsigned size) override {
+        if (_elements.size() == 0)
+            _elements.resize(size);
+        _batch_size = size;
     }
 
     bool single_value() const override {
@@ -108,7 +108,7 @@ class UniformRand : public Parameter<T> {
     T _start;
     T _end;
     T _updated_val;
-    std::vector<T> _array;
+    std::vector<T> _elements;
     std::mt19937 _generator;
     std::mutex _lock;
     unsigned _batch_size;
@@ -195,12 +195,12 @@ struct CustomRand : public Parameter<T> {
     void renew_array() {
         for (uint i = 0; i < _batch_size; i++) {
             renew_value();
-            _array[i] = _updated_val;
+            _elements[i] = _updated_val;
         }
     }
 
     void renew() override {
-        if (_array.size() > 0) {
+        if (_elements.size()) {
             renew_array();
         } else {
             renew_value();
@@ -211,13 +211,13 @@ struct CustomRand : public Parameter<T> {
     };
 
     std::vector<T> get_array() override {
-        return _array;
+        return _elements;
     }
 
-    void create_array(unsigned batch_size) override {
-        if (_array.size() == 0)
-            _array.resize(batch_size);
-        _batch_size = batch_size;
+    void create_array(unsigned size) override {
+        if (_elements.size() == 0)
+            _elements.resize(size);
+        _batch_size = size;
     }
 
     bool single_value() const override {
@@ -230,7 +230,7 @@ struct CustomRand : public Parameter<T> {
     std::vector<double> _comltv_dist;  //!< commulative probabilities
     double _mean;
     T _updated_val;
-    std::vector<T> _array;
+    std::vector<T> _elements;
     std::mt19937 _generator;
     std::mutex _lock;
     unsigned _batch_size;

--- a/rocAL/include/parameters/parameter_simple.h
+++ b/rocAL/include/parameters/parameter_simple.h
@@ -35,9 +35,35 @@ class SimpleParameter : public Parameter<T> {
     T get() override {
         return _val;
     }
-    int update(T new_val) {
+
+    std::vector<T> get_array() override {
+        return _array;
+    }
+
+    void update_single_value(T new_val) {
         _val = new_val;
+    }
+
+    void update_array(T new_val) {
+        for (uint i = 0; i < _batch_size; i++) {
+            update_single_value(new_val);
+            _array[i] = _val;
+        }
+    }
+
+    int update(T new_val) {
+        if (_array.size() > 0)
+            update_array(new_val);
+        else
+            update_single_value(new_val);
         return 0;
+    }
+
+    void create_array(unsigned batch_size) override {
+        if (_array.size() == 0)
+            _array.resize(batch_size);
+        _batch_size = batch_size;
+        update(_val);
     }
 
     ~SimpleParameter() = default;
@@ -48,6 +74,8 @@ class SimpleParameter : public Parameter<T> {
 
    private:
     T _val;
+    std::vector<T> _array;
+    unsigned _batch_size;
 };
 using pIntParam = std::shared_ptr<SimpleParameter<int>>;
 using pFloatParam = std::shared_ptr<SimpleParameter<float>>;

--- a/rocAL/include/parameters/parameter_simple.h
+++ b/rocAL/include/parameters/parameter_simple.h
@@ -52,7 +52,7 @@ class SimpleParameter : public Parameter<T> {
     }
 
     int update(T new_val) {
-        if (_array.size() > 0)
+        if (_array.size())
             update_array(new_val);
         else
             update_single_value(new_val);

--- a/rocAL/include/parameters/parameter_simple.h
+++ b/rocAL/include/parameters/parameter_simple.h
@@ -57,8 +57,7 @@ class SimpleParameter : public Parameter<T> {
     }
 
     void create_array(unsigned array_size) override {
-        if (param_values.size() == 0)
-            param_values.resize(array_size);
+        if (param_values.size() == 0) param_values.resize(array_size);
     }
 
     ~SimpleParameter() = default;

--- a/rocAL/include/parameters/parameter_simple.h
+++ b/rocAL/include/parameters/parameter_simple.h
@@ -37,7 +37,7 @@ class SimpleParameter : public Parameter<T> {
     }
 
     std::vector<T> get_array() override {
-        return _array;
+        return _values;
     }
 
     void update_single_value(T new_val) {
@@ -45,24 +45,20 @@ class SimpleParameter : public Parameter<T> {
     }
 
     void update_array(T new_val) {
-        for (uint i = 0; i < _batch_size; i++) {
-            update_single_value(new_val);
-            _array[i] = _val;
-        }
+    std::fill(_values.begin(), _values.end(), _val); 
     }
 
     int update(T new_val) {
-        if (_array.size())
+        if (_values.size())
             update_array(new_val);
         else
             update_single_value(new_val);
         return 0;
     }
 
-    void create_array(unsigned batch_size) override {
-        if (_array.size() == 0)
-            _array.resize(batch_size);
-        _batch_size = batch_size;
+    void create_array(unsigned array_size) override {
+        if (_values.size() == 0)
+            _values.resize(array_size);
         update(_val);
     }
 
@@ -74,8 +70,7 @@ class SimpleParameter : public Parameter<T> {
 
    private:
     T _val;
-    std::vector<T> _array;
-    unsigned _batch_size;
+    std::vector<T> _values; //!< The updated values will be used in parameter_vx.h file 
 };
 using pIntParam = std::shared_ptr<SimpleParameter<int>>;
 using pFloatParam = std::shared_ptr<SimpleParameter<float>>;

--- a/rocAL/include/parameters/parameter_simple.h
+++ b/rocAL/include/parameters/parameter_simple.h
@@ -37,7 +37,7 @@ class SimpleParameter : public Parameter<T> {
     }
 
     std::vector<T> get_array() override {
-        return _values;
+        return param_values;
     }
 
     void update_single_value(T new_val) {
@@ -45,11 +45,11 @@ class SimpleParameter : public Parameter<T> {
     }
 
     void update_array(T new_val) {
-    std::fill(_values.begin(), _values.end(), _val); 
+    std::fill(param_values.begin(), param_values.end(), _val); 
     }
 
     int update(T new_val) {
-        if (_values.size())
+        if (param_values.size())
             update_array(new_val);
         else
             update_single_value(new_val);
@@ -57,8 +57,8 @@ class SimpleParameter : public Parameter<T> {
     }
 
     void create_array(unsigned array_size) override {
-        if (_values.size() == 0)
-            _values.resize(array_size);
+        if (param_values.size() == 0)
+            param_values.resize(array_size);
         update(_val);
     }
 
@@ -70,7 +70,7 @@ class SimpleParameter : public Parameter<T> {
 
    private:
     T _val;
-    std::vector<T> _values; //!< The updated values will be used in parameter_vx.h file 
+    std::vector<T> param_values; //!< The updated values will be used in parameter_vx.h file 
 };
 using pIntParam = std::shared_ptr<SimpleParameter<int>>;
 using pFloatParam = std::shared_ptr<SimpleParameter<float>>;

--- a/rocAL/include/parameters/parameter_simple.h
+++ b/rocAL/include/parameters/parameter_simple.h
@@ -45,7 +45,7 @@ class SimpleParameter : public Parameter<T> {
     }
 
     void update_array(T new_val) {
-    std::fill(param_values.begin(), param_values.end(), _val); 
+        std::fill(param_values.begin(), param_values.end(), _val);
     }
 
     int update(T new_val) {
@@ -59,7 +59,6 @@ class SimpleParameter : public Parameter<T> {
     void create_array(unsigned array_size) override {
         if (param_values.size() == 0)
             param_values.resize(array_size);
-        update(_val);
     }
 
     ~SimpleParameter() = default;
@@ -70,7 +69,7 @@ class SimpleParameter : public Parameter<T> {
 
    private:
     T _val;
-    std::vector<T> param_values; //!< The updated values will be used in parameter_vx.h file 
+    std::vector<T> param_values;  //!< The updated values will be used in parameter_vx.h file
 };
 using pIntParam = std::shared_ptr<SimpleParameter<int>>;
 using pFloatParam = std::shared_ptr<SimpleParameter<float>>;

--- a/rocAL/include/parameters/parameter_vx.h
+++ b/rocAL/include/parameters/parameter_vx.h
@@ -52,11 +52,12 @@ class ParameterVX {
             THROW("Reading vx scalar failed" + TOSTR(status));
     }
     void create_array(std::shared_ptr<Graph> graph, vx_enum data_type, unsigned batch_size) {
-        // _arrVal = (T*)malloc(sizeof(T) * _batch_size);
         _batch_size = batch_size;
-        _arrVal.resize(_batch_size);
+        _param->create_array(_batch_size);
         _array = vxCreateArray(vxGetContext((vx_reference)graph->get()), data_type, _batch_size);
-        vxAddArrayItems(_array, _batch_size, _arrVal.data(), sizeof(T));
+        auto status = vxAddArrayItems(_array, _batch_size, get_array().data(), sizeof(T));
+        if (status != 0)
+            THROW(" vxAddArrayItems failed in create_array (ParameterVX): " + TOSTR(status))
         update_array();
     }
     void set_param(Parameter<T>* param) {
@@ -96,11 +97,7 @@ class ParameterVX {
     }
     void update_array() {
         vx_status status;
-        for (uint i = 0; i < _batch_size; i++) {
-            _arrVal[i] = renew();
-            // INFO("update_array: " + TOSTR(i) + "," + TOSTR(_arrVal[i]));
-        }
-        status = vxCopyArrayRange((vx_array)_array, 0, _batch_size, sizeof(T), _arrVal.data(), VX_WRITE_ONLY, VX_MEMORY_TYPE_HOST);
+        status = vxCopyArrayRange((vx_array)_array, 0, _batch_size, sizeof(T), get_array().data(), VX_WRITE_ONLY, VX_MEMORY_TYPE_HOST);
         if (status != 0)
             THROW(" vxCopyArrayRange failed in update_array (ParameterVX): " + TOSTR(status))
     }
@@ -109,12 +106,15 @@ class ParameterVX {
         return _param->get();
     }
 
+    std::vector<T> get_array() {
+        return _param->get_array();
+    }
+
    private:
     vx_scalar _scalar;
-    vx_array _array;
+    vx_array _array = nullptr;
     Parameter<T>* _param;
     T _val;
-    std::vector<T> _arrVal;
     unsigned _batch_size;
     unsigned OVX_PARAM_IDX;
     const T _DEFAULT_RANGE_START;

--- a/rocAL/source/parameters/parameter_factory.cpp
+++ b/rocAL/source/parameters/parameter_factory.cpp
@@ -104,33 +104,46 @@ void ParameterFactory::generate_seed() {
     _seed = rd();
 }
 
+int64_t
+ParameterFactory::get_seed_from_seedsequence() {
+    increment_seed_sequence_idx();
+    return _seed_vector[_seed_sequence_idx];
+}
+
+void ParameterFactory::increment_seed_sequence_idx() {
+    _seed_sequence_idx = (_seed_sequence_idx + 1) % MAX_SEEDS;
+}
+
 void ParameterFactory::set_seed(unsigned seed) {
     _seed = seed;
+    _seed_vector.resize(MAX_SEEDS);
+    std::seed_seq ss{seed};
+    ss.generate(_seed_vector.begin(), _seed_vector.end());
 }
 
 IntParam* ParameterFactory::create_uniform_int_rand_param(int start, int end) {
-    auto gen = new UniformRand<int>(start, end, _seed);
+    auto gen = new UniformRand<int>(start, end, get_seed_from_seedsequence());
     auto ret = new IntParam(gen, RocalParameterType::RANDOM_UNIFORM);
     _parameters.insert(gen);
     return ret;
 }
 
 FloatParam* ParameterFactory::create_uniform_float_rand_param(float start, float end) {
-    auto gen = new UniformRand<float>(start, end, _seed);
+    auto gen = new UniformRand<float>(start, end, get_seed_from_seedsequence());
     auto ret = new FloatParam(gen, RocalParameterType::RANDOM_UNIFORM);
     _parameters.insert(gen);
     return ret;
 }
 
 IntParam* ParameterFactory::create_custom_int_rand_param(const int* value, const double* frequencies, size_t size) {
-    auto gen = new CustomRand<int>(value, frequencies, size, _seed);
+    auto gen = new CustomRand<int>(value, frequencies, size, get_seed_from_seedsequence());
     auto ret = new IntParam(gen, RocalParameterType::RANDOM_CUSTOM);
     _parameters.insert(gen);
     return ret;
 }
 
 FloatParam* ParameterFactory::create_custom_float_rand_param(const float* value, const double* frequencies, size_t size) {
-    auto gen = new CustomRand<float>(value, frequencies, size, _seed);
+    auto gen = new CustomRand<float>(value, frequencies, size, get_seed_from_seedsequence());
     auto ret = new FloatParam(gen, RocalParameterType::RANDOM_CUSTOM);
     _parameters.insert(gen);
     return ret;

--- a/rocAL/source/parameters/parameter_factory.cpp
+++ b/rocAL/source/parameters/parameter_factory.cpp
@@ -106,12 +106,9 @@ void ParameterFactory::generate_seed() {
 
 int64_t
 ParameterFactory::get_seed_from_seedsequence() {
-    increment_seed_sequence_idx();
-    return _seed_vector[_seed_sequence_idx];
-}
-
-void ParameterFactory::increment_seed_sequence_idx() {
+    auto seed = _seed_vector[_seed_sequence_idx];
     _seed_sequence_idx = (_seed_sequence_idx + 1) % MAX_SEEDS;
+    return seed;
 }
 
 void ParameterFactory::set_seed(unsigned seed) {


### PR DESCRIPTION
- rocAL Parameter creation and updation moved from parameter_vx.h to respective param classes (parameter_random.h & parameter_simple.h) so that the rocAL random / simple parameter's instance is created only once and updated when renew is called from master_graph
- Added seed vector used for instantiating random parameter with different seed