### PR TITLE
Bug Fix - Tests fall back to CPU if CuPy unavailable

### DIFF
--- a/rocAL_pybind/amd/rocal/plugin/generic.py
+++ b/rocAL_pybind/amd/rocal/plugin/generic.py
@@ -23,7 +23,6 @@
 #
 # @brief File containing iterators for generic use case
 
-import cupy as cp
 import numpy as np
 import rocal_pybind as b
 import amd.rocal.types as types
@@ -49,6 +48,12 @@ class ROCALGenericIterator(object):
         self.multiplier = multiplier
         self.offset = offset
         self.device = device
+        if self.device is "gpu" or "cuda":
+            try:
+                import cupy as cp
+            except ImportError:
+                print('info: Import CuPy failed. Falling back to CPU!')
+                self.device = "cpu"
         self.device_id = device_id
         self.reverse_channels = reverse_channels
         self.tensor_dtype = tensor_dtype

--- a/rocAL_pybind/amd/rocal/plugin/tf.py
+++ b/rocAL_pybind/amd/rocal/plugin/tf.py
@@ -23,7 +23,6 @@
 # @brief File containing iterators to be used with TF trainings
 
 import numpy as np
-import cupy as cp
 import ctypes
 import rocal_pybind as b
 import amd.rocal.types as types
@@ -92,6 +91,12 @@ class ROCALGenericIteratorDetection(object):
         self.multiplier = multiplier or [1.0, 1.0, 1.0]
         self.offset = offset or [0.0, 0.0, 0.0]
         self.device = device
+        if self.device is "gpu" or "cuda":
+            try:
+                import cupy as cp
+            except ImportError:
+                print('info: Import CuPy failed. Falling back to CPU!')
+                self.device = "cpu"
         self.device_id = device_id
         self.reverse_channels = reverse_channels
         self.tensor_dtype = tensor_dtype

--- a/tests/python_api/decoder.py
+++ b/tests/python_api/decoder.py
@@ -6,7 +6,6 @@ import amd.rocal.fn as fn
 import amd.rocal.types as types
 import matplotlib.gridspec as gridspec
 import matplotlib.pyplot as plt
-import cupy as cp
 
 seed = 1549361629
 image_dir = "../../data/images/AMD-tinyDataSet/"
@@ -26,7 +25,11 @@ def show_images(image_batch, device):
         if device == "cpu":
             plt.imshow(img)
         else:
-            plt.imshow(cp.asnumpy(img))
+            try:
+                import cupy as cp
+                plt.imshow(cp.asnumpy(img))
+            except ImportError:
+                pass
     plt.show()
 
 

--- a/tests/python_api/tf_classification_reader.py
+++ b/tests/python_api/tf_classification_reader.py
@@ -26,14 +26,17 @@ import amd.rocal.fn as fn
 import tensorflow as tf
 import numpy as np
 from parse_config import parse_args
-import cupy as cp
 
 
 def draw_patches(img, idx, device_type, args=None):
     import cv2
     args = parse_args()
     if device_type == "gpu":
-        img = cp.asnumpy(img)
+        try:
+            import cupy as cp
+            img = cp.asnumpy(img)
+        except ImportError:
+            pass
     if not args.NHWC:
         img = img.transpose([0, 1, 2])
     image = cv2.cvtColor(img, cv2.COLOR_RGB2BGR)

--- a/tests/python_api/tf_detection_reader.py
+++ b/tests/python_api/tf_detection_reader.py
@@ -25,7 +25,6 @@ import tensorflow as tf
 import amd.rocal.fn as fn
 import numpy as np
 import os
-import cupy as cp
 from parse_config import parse_args
 
 
@@ -53,7 +52,11 @@ def draw_patches(img, idx, bboxes, device_type, args=None):
     import cv2
     args = parse_args()
     if device_type == "gpu":
-        img = cp.asnumpy(img)
+        try:
+            import cupy as cp
+            img = cp.asnumpy(img)
+        except ImportError:
+            pass
     if not args.NHWC:
         img = img.transpose([0, 1, 2])
     image = cv2.cvtColor(img, cv2.COLOR_RGB2BGR)

--- a/tests/python_api/unit_test.py
+++ b/tests/python_api/unit_test.py
@@ -26,7 +26,6 @@ from parse_config import parse_args
 import os
 import sys
 import cv2
-import cupy as cp
 
 INTERPOLATION_TYPES = {
     0: types.NEAREST_NEIGHBOR_INTERPOLATION,
@@ -48,7 +47,11 @@ SCALING_MODES = {
 def draw_patches(img, idx, device, args=None):
     # image is expected as a tensor, bboxes as numpy
     if device == "gpu":
-        img = cp.asnumpy(img)
+        try:
+            import cupy as cp
+            img = cp.asnumpy(img)
+        except ImportError:
+            pass
     if args.fp16:
         img = (img).astype('uint8')
     if not args.color_format:
@@ -66,7 +69,11 @@ def draw_patches(img, idx, device, args=None):
 
 def dump_meta_data(labels, device, args=None):
     if device == "gpu":
-        labels = cp.asnumpy(labels)
+        try:
+            import cupy as cp
+            labels = cp.asnumpy(labels)
+        except ImportError:
+            pass
     labels_list = labels.tolist()
     with open(args.output_file_name, 'w') as file:
         for label in labels_list:


### PR DESCRIPTION
Adding a try...except block to check for CuPy. Upgrading to rocm6.2 fails to build CuPy. This PR makes the generic and tf plugins fall back and use CPU is CuPy is not available. Tested decoder.py, tf_classification and tf_detection and unit_test.sh