### PR TITLE
Introduce flag in CMake to enable Audio support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,7 @@ option(GPU_SUPPORT      "Build rocAL with GPU Support"         ON)
 option(BUILD_PYPACKAGE  "Build rocAL Python Package"           ON)
 option(BUILD_WITH_AMD_ADVANCE  "Build rocAL with Advanced GPU support" OFF)
 option(PYTHON_VERSION_SUGGESTED "Python version to build rocal" "")
+option(AUDIO_SUPPORT "Build rocAL with Audio features" OFF)
 
 set(DEFAULT_BUILD_TYPE "Release")
 
@@ -136,6 +137,9 @@ if(HIP_FOUND)
   if(HIP_VERSION  VERSION_GREATER 5.7.50701)
     set(BUILD_WITH_AMD_ADVANCE ON)
   endif()
+  if(HIP_VERSION VERSION_GREATER 6.2)
+    set(AUDIO_SUPPORT ON)
+  endif()
 endif()
 
 message("-- ${Cyan}rocAL Developer Options${ColourReset}")
@@ -144,6 +148,7 @@ message("-- ${Cyan}     -D BACKEND=${BACKEND} [Select rocAL Backend [options:CPU
 message("-- ${Cyan}     -D BUILD_PYPACKAGE=${BUILD_PYPACKAGE} [rocAL Python Package(default:ON)]${ColourReset}")
 message("-- ${Cyan}     -D BUILD_WITH_AMD_ADVANCE=${BUILD_WITH_AMD_ADVANCE} [rocAL support for advanced GPU(default:OFF)]${ColourReset}")
 message("-- ${Cyan}     -D PYTHON_VERSION_SUGGESTED=${PYTHON_VERSION_SUGGESTED} [User provided python version to use for rocAL Python Bindings(default:System Version)]${ColourReset}")
+message("-- ${Cyan}     -D AUDIO_SUPPORT=${AUDIO_SUPPORT} [rocAL support for Audio features(default:OFF)]${ColourReset}")
 
 add_subdirectory(rocAL)
 if(BUILD_PYPACKAGE)

--- a/README.md
+++ b/README.md
@@ -160,7 +160,8 @@ git clone https://github.com/ROCm/rocAL.git
 > * `sudo` required for pybind installation
 
 >[!IMPORTANT]
-> Use `-D PYTHON_VERSION_SUGGESTED=3.x` with `cmake` for using a specific Python3 version if required.
+> * Use `-D PYTHON_VERSION_SUGGESTED=3.x` with `cmake` for using a specific Python3 version if required.
+> * Use `-D AUDIO_SUPPORT=ON` to enable Audio features, Audio support will be enabled by default with ROCm versions > 6.2
 
   + run tests - [test option instructions](https://github.com/ROCm/MIVisionX/wiki/CTest)
   ```shell

--- a/rocAL/CMakeLists.txt
+++ b/rocAL/CMakeLists.txt
@@ -299,11 +299,13 @@ if(${BUILD_ROCAL})
     # SndFile
     if(NOT SNDFILE_FOUND)
         message("-- ${Yellow}NOTE: rocAL built without SndFile - Audio Functionalities will not be supported${ColourReset}")
-    else()
+    elseif(AUDIO_SUPPORT)
         include_directories(${SNDFILE_INCLUDE_DIRS})
         set(LINK_LIBRARY_LIST ${LINK_LIBRARY_LIST} ${SNDFILE_LIBRARIES})
         message("-- ${White}rocAL built with Audio Functionality${ColourReset}")
         target_compile_definitions(${PROJECT_NAME} PUBLIC -DROCAL_AUDIO)
+    else()
+        message("-- ${Yellow}NOTE: rocAL built without Audio support - Audio Functionalities will not be enabled${ColourReset}")
     endif()
     # -Wall -- Enable most warning messages
     # -mavx2 -- Support MMX, SSE, SSE2, SSE3, SSSE3, SSE4.1, SSE4.2, AVX and AVX2 built-in functions and code generation


### PR DESCRIPTION
- Introduce CMake flag to enable Audio support
- Add changes to enable Audio features only for ROCm version > 6.2