### PR TITLE
Fix org used for linting workflow by rocm-docs-core

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -9,4 +9,4 @@ on:
 jobs:
   call-workflow-passing-data:
     name: Documentation
-    uses: RadeonOpenCompute/rocm-docs-core/.github/workflows/linting.yml@develop
+    uses: ROCm/rocm-docs-core/.github/workflows/linting.yml@develop


### PR DESCRIPTION
rocm-docs-core moved from RadeonOpenCompute to ROCm