### PR TITLE
Docs - Fix a few erroneous links to the examples directory

### DIFF
--- a/docs/how-to/framework.rst
+++ b/docs/how-to/framework.rst
@@ -191,7 +191,7 @@ Follow these steps:
                     train_label_one_hot_list = get_label_one_hot(train_label_ndArray)
 
 
-4. To see and run a sample training script, refer to `rocAL TensorFlow example <https://github.com/ROCm/rocAL/tree/master/rocAL/docs/examples/tf/pets_training>`_.
+4. To see and run a sample training script, refer to `rocAL TensorFlow example <https://github.com/ROCm/rocAL/tree/master/docs/examples/tf/pets_training>`_.
 
 .. __resnet50:
 

--- a/docs/how-to/overview.rst
+++ b/docs/how-to/overview.rst
@@ -109,4 +109,4 @@ Decoders                Description
 ======================  ========================================
 
 To see examples demonstrating the usage of decoders and readers, see 
-`rocAL Python Examples <https://github.com/ROCm/rocAL/tree/master/rocAL/docs/examples>`_.
+`rocAL Python Examples <https://github.com/ROCm/rocAL/tree/master/docs/examples>`_.

--- a/docs/user_guide/ch1.md
+++ b/docs/user_guide/ch1.md
@@ -80,4 +80,4 @@ rocAL operators offer the flexibility to run on CPU or GPU for building hybrid p
 | Image_random_crop | Decodes and randomly crops JPEG images |
 | Image_slice       | Decodes and slices JPEG images         |
 
-To see examples demonstrating the usage of decoders and readers, [click here](https://github.com/ROCm/rocAL/tree/master/rocAL/docs/examples)
+To see examples demonstrating the usage of decoders and readers, [click here](https://github.com/ROCm/rocAL/tree/master/docs/examples)


### PR DESCRIPTION
This fixes three bad links to the examples directory or one of its subdirectories.