### PR TITLE
Updated 6.2.1 changelog so that it reflects the 6.2.1 RN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,67 +49,42 @@
 * rocAL Setup Script - `V2.5.0`
 * Dependencies for all the above packages
 
-## rocAL 2.0.0
+## rocAL 2.0.0 for ROCm 6.2.1
 
 ### Changes
-* Support for audio loader and decoder, which uses libsndfile library to decode wav files
-* C++ rocAL audio unit test and python script to run and compare the outputs
-* Python support for audio decoders
-* Pytorch iterator for Audio
-* Python audio unit test, and support to verify outputs
-* rocDecode for HW decode
-* Support for Audio augmentation - PreEmphasis filter
-* Support for reading from file lists in file reader
-* Support for Audio augmentation - Spectrogram
-* Support for Audio augmentation - ToDecibels
-* Support for down-mixing audio channels during decoding
-* Support for Audio augmentation - Resample
-* Support for TensorTensorAdd and TensorScalarMultiply operations
-* Support for Uniform and Normal distribution nodes
-* Support for Audio augmentation - NonSilentRegionDetection 
-* Support for generic augmentation - Slice 
-* Support for generic augmentation - Normalize
-* Support for Audio augmentation - MelFilterBank
 
-### Removals
-* VX Image processing deprecated
-
-### Optimizations
-
-* Packages - dev & tests
-* Tests
-* Setup Script
-* CentOS 7 support
-* SLES 15 SP5 support
-
-### Changed
+* The new version of rocAL introduces many new features, but does not modify any of the existing public API functions.However, the version number was incremented from 1.3 to 2.0.
+  Applications linked to version 1.3 must be recompiled to link against version 2.0.
+* Added development and test packages.
+* Added C++ rocAL audio unit test and Python script to run and compare the outputs.
+* Added Python support for audio decoders.
+* Added Pytorch iterator for audio.
+* Added Python audio unit test and support to verify outputs.
+* Added rocDecode for HW decode.
+* Added support for:
+  * Audio loader and decoder, which uses libsndfile library to decode wav files
+  * Audio augmentation - PreEmphasis filter, Spectrogram, ToDecibels, Resample, NonSilentRegionDetection. MelFilterBank
+  * Generic augmentation - Slice, Normalize
+  * Reading from file lists in file reader
+  * Downmixing audio channels during decoding
+  * TensorTensorAdd and TensorScalarMultiply operations
+  * Uniform and Normal distribution nodes
+* Image to tensor updates
 * ROCm install - use case graphics removed
 
-### Resolved issues
-* Tests & readme
-
 ### Known issues
-* Requires custom dependencies installed
 
-### Tested Configurations
+* Dependencies are not installed with the rocAL package installer. Dependencies must be installed with the prerequisite setup script provided. See the [rocAL README on GitHub](https://github.com/ROCm/rocAL/blob/docs/6.2.1/README.md#prerequisites-setup-script) for details.
 
-* Linux distribution
-  * Ubuntu - `20.04` / `22.04`
-  * CentOS - `7`
-  * RedHat - `8` / `9`
-  * SLES - `15-SP5`
-* ROCm: rocm-core - `6.2.0.60200`
-* RPP - `rpp` & `rpp-dev`/`rpp-devel`
-* MIVisionX - `mivisionx` & `mivisionx-dev`/`mivisionx-devel`
-* Protobuf - `libprotobuf-dev`/`protobuf-devel`
-* RapidJSON - `https://github.com/Tencent/rapidjson`
-* Turbo JPEG - [Version 3.0.2](https://libjpeg-turbo.org/)
-* PyBind11 - [v2.11.1](https://github.com/pybind/pybind11)
-* FFMPEG - `ffmpeg 4` dev package
-* OpenCV - `libopencv` / [4.6.0](https://github.com/opencv/opencv/releases/tag/4.6.0)
-* libsndfile - [1.0.31](https://github.com/libsndfile/libsndfile/releases/tag/1.0.31)
-* rocAL Setup Script - `V2.6.0`
-* Dependencies for all the above packages
+### **rocBLAS** (4.2.1)
+
+#### Removals
+
+* Removed Device_Memory_Allocation.pdf link in documentation.
+
+#### Resolved issues
+
+* Fixed error/warning message during `rocblas_set_stream()` call.
 
 ## rocAL 1.0.0
 


### PR DESCRIPTION
Updated the changelog file for 6.2.1 so that it reflects what is in the 6.2.1 Release Notes and conforms to the documentation standards. 

The changelog for subsequent versions should conform to this standard.