### PR TITLE
Remove libjpeg check in CMake

### DIFF
--- a/cmake/FindTurboJpeg.cmake
+++ b/cmake/FindTurboJpeg.cmake
@@ -53,32 +53,7 @@ find_library(TurboJpeg_LIBRARIES
 )
 mark_as_advanced(TurboJpeg_LIBRARIES)
 
-# Libjpeg
-find_path(LIBJPEG_INCLUDE_DIR 
-    NAMES jpeglib.h
-    HINTS
-    $ENV{TURBO_JPEG_PATH}/include
-    PATHS
-    /usr/include
-    ${TURBO_JPEG_PATH}/include
-    /opt/libjpeg-turbo/include
-)
-mark_as_advanced(LIBJPEG_INCLUDE_DIR)
-
-find_library(LIBJPEG_LIBRARIES
-    NAMES libjpeg${SHARED_LIB_TYPE}
-    HINTS
-    $ENV{TURBO_JPEG_PATH}/lib
-    $ENV{TURBO_JPEG_PATH}/lib64
-    PATHS
-    /usr/lib
-    ${TURBO_JPEG_PATH}/lib
-    ${TURBO_JPEG_PATH}/lib64
-    /opt/libjpeg-turbo/lib
-)
-mark_as_advanced(LIBJPEG_LIBRARIES)
-
-if(TurboJpeg_LIBRARIES AND TurboJpeg_INCLUDE_DIRS AND LIBJPEG_INCLUDE_DIR AND LIBJPEG_LIBRARIES)
+if(TurboJpeg_LIBRARIES AND TurboJpeg_INCLUDE_DIRS)
     set(TurboJpeg_FOUND TRUE)
 endif( )
 
@@ -88,15 +63,11 @@ find_package_handle_standard_args( TurboJpeg
     REQUIRED_VARS
         TurboJpeg_LIBRARIES 
         TurboJpeg_INCLUDE_DIRS
-        LIBJPEG_INCLUDE_DIR
-        LIBJPEG_LIBRARIES
 )
 
 set(TurboJpeg_FOUND ${TurboJpeg_FOUND} CACHE INTERNAL "")
 set(TurboJpeg_LIBRARIES ${TurboJpeg_LIBRARIES} CACHE INTERNAL "")
 set(TurboJpeg_INCLUDE_DIRS ${TurboJpeg_INCLUDE_DIRS} CACHE INTERNAL "")
-set(LIBJPEG_LIBRARIES ${LIBJPEG_LIBRARIES} CACHE INTERNAL "")
-set(LIBJPEG_INCLUDE_DIR ${LIBJPEG_INCLUDE_DIR} CACHE INTERNAL "")
 
 if(TurboJpeg_FOUND)
     message("-- ${White}Using Turbo JPEG -- \n\tLibraries:${TurboJpeg_LIBRARIES} \n\tIncludes:${TurboJpeg_INCLUDE_DIRS}${ColourReset}")   


### PR DESCRIPTION
- Removes the check for LIBJPEG_LIBRARIES and LIBJPEG_INCLUDE_DIRS from FindTurboJPEG.cmake
- JPEG includes are provided by turbojpeg package so its sufficient to only check for turbojpeg library
- Fixes #287 