### PR TITLE
Add audio tests to CI 

### DIFF
--- a/.jenkins/common.groovy
+++ b/.jenkins/common.groovy
@@ -91,6 +91,8 @@ def runTestCommand (platform, project) {
                     make -j
                     ./external_source ../MIVisionX-data-main/rocal_data/coco/coco_10_img/images/
                     ./external_source ../MIVisionX-data-main/rocal_data/coco/coco_10_img/images/ 1
+                    cd ../../ && mkdir -p audio-tests && cd audio-tests
+                    python3 /opt/rocm/share/rocal/test/audio_tests/audio_tests.py
                     cd ../../
                     sudo ${packageManager} install lcov ${toolsPackage}
                     ${llvmLocation}/llvm-profdata merge -sparse rawdata/*.profraw -o rocal.profdata

--- a/.jenkins/common.groovy
+++ b/.jenkins/common.groovy
@@ -93,7 +93,7 @@ def runTestCommand (platform, project) {
                     ./external_source ../MIVisionX-data-main/rocal_data/coco/coco_10_img/images/ 1
                     cd ../../ && mkdir -p audio-tests && cd audio-tests
                     python3 /opt/rocm/share/rocal/test/audio_tests/audio_tests.py
-                    cd ../../
+                    cd ../
                     sudo ${packageManager} install lcov ${toolsPackage}
                     ${llvmLocation}/llvm-profdata merge -sparse rawdata/*.profraw -o rocal.profdata
                     ${llvmLocation}/llvm-cov export -object release/lib/librocal.so --instr-profile=rocal.profdata --format=lcov > coverage.info


### PR DESCRIPTION
Code cov up by 4.32%
Now at 46.91%
https://app.codecov.io/gh/ROCm/rocAL/pull/320
jenkins report: http://math-ci.amd.com/blue/rest/organizations/jenkins/pipelines/mainline/pipelines/precheckin/pipelines/rocAL/branches/PR-320/runs/2/nodes/277/steps/298/log/?start=0
ready to merge