### PR TITLE
Cherry-pick 7.0.2-RC1:  RPATH Fix - Temp OpenMP

### DIFF
--- a/rocAL_pybind/CMakeLists.txt
+++ b/rocAL_pybind/CMakeLists.txt
@@ -211,8 +211,9 @@ if(${BUILD_ROCAL_PYBIND})
     # half
     include_directories(${HALF_INCLUDE_DIRS})
     # OpenMP
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
+    #set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
     set(LINK_LIBRARY_LIST ${LINK_LIBRARY_LIST} ${OpenMP_CXX_LIBRARIES})
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wl,-rpath='$ORIGIN:$ORIGIN/llvm/lib'")
 
     file(GLOB_RECURSE pyfiles amd/*.py)
     file(GLOB_RECURSE sources *.cpp)


### PR DESCRIPTION
```
readelf -d /opt/rocm/lib/rocal_pybind.cpython-310-x86_64-linux-gnu.so 

Dynamic section at offset 0x11b398 contains 94 entries:
  Tag        Type                         Name/Value
 0x000000000000001d (RUNPATH)            Library runpath: [$ORIGIN:$ORIGIN/llvm/lib]
 0x0000000000000001 (NEEDED)             Shared library: [libopenvx.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libvx_rpp.so.3]
 0x0000000000000001 (NEEDED)             Shared library: [libturbojpeg.so.0]
 0x0000000000000001 (NEEDED)             Shared library: [librocal.so.2]
 0x0000000000000001 (NEEDED)             Shared library: [libomp.so]
 0x0000000000000001 (NEEDED)             Shared library: [libprotobuf.so.23]
 0x0000000000000001 (NEEDED)             Shared library: [liblmdb.so.0]
 0x0000000000000001 (NEEDED)             Shared library: [libopencv_stitching.so.4.5d]
 0x0000000000000001 (NEEDED)             Shared library: [libopencv_alphamat.so.4.5d]
 0x0000000000000001 (NEEDED)             Shared library: [libopencv_aruco.so.4.5d]
 0x0000000000000001 (NEEDED)             Shared library: [libopencv_barcode.so.4.5d]
 0x0000000000000001 (NEEDED)             Shared library: [libopencv_bgsegm.so.4.5d]
 0x0000000000000001 (NEEDED)             Shared library: [libopencv_bioinspired.so.4.5d]
 0x0000000000000001 (NEEDED)             Shared library: [libopencv_ccalib.so.4.5d]
 0x0000000000000001 (NEEDED)             Shared library: [libopencv_dnn_objdetect.so.4.5d]
 0x0000000000000001 (NEEDED)             Shared library: [libopencv_dnn_superres.so.4.5d]
 0x0000000000000001 (NEEDED)             Shared library: [libopencv_dpm.so.4.5d]
 0x0000000000000001 (NEEDED)             Shared library: [libopencv_face.so.4.5d]
 0x0000000000000001 (NEEDED)             Shared library: [libopencv_freetype.so.4.5d]
 0x0000000000000001 (NEEDED)             Shared library: [libopencv_fuzzy.so.4.5d]
 0x0000000000000001 (NEEDED)             Shared library: [libopencv_hdf.so.4.5d]
 0x0000000000000001 (NEEDED)             Shared library: [libopencv_hfs.so.4.5d]
 0x0000000000000001 (NEEDED)             Shared library: [libopencv_img_hash.so.4.5d]
 0x0000000000000001 (NEEDED)             Shared library: [libopencv_intensity_transform.so.4.5d]
 0x0000000000000001 (NEEDED)             Shared library: [libopencv_line_descriptor.so.4.5d]
 0x0000000000000001 (NEEDED)             Shared library: [libopencv_mcc.so.4.5d]
 0x0000000000000001 (NEEDED)             Shared library: [libopencv_quality.so.4.5d]
 0x0000000000000001 (NEEDED)             Shared library: [libopencv_rapid.so.4.5d]
 0x0000000000000001 (NEEDED)             Shared library: [libopencv_reg.so.4.5d]
 0x0000000000000001 (NEEDED)             Shared library: [libopencv_rgbd.so.4.5d]
 0x0000000000000001 (NEEDED)             Shared library: [libopencv_saliency.so.4.5d]
 0x0000000000000001 (NEEDED)             Shared library: [libopencv_shape.so.4.5d]
 0x0000000000000001 (NEEDED)             Shared library: [libopencv_stereo.so.4.5d]
 0x0000000000000001 (NEEDED)             Shared library: [libopencv_structured_light.so.4.5d]
 0x0000000000000001 (NEEDED)             Shared library: [libopencv_phase_unwrapping.so.4.5d]
 0x0000000000000001 (NEEDED)             Shared library: [libopencv_superres.so.4.5d]
 0x0000000000000001 (NEEDED)             Shared library: [libopencv_optflow.so.4.5d]
 0x0000000000000001 (NEEDED)             Shared library: [libopencv_surface_matching.so.4.5d]
 0x0000000000000001 (NEEDED)             Shared library: [libopencv_tracking.so.4.5d]
 0x0000000000000001 (NEEDED)             Shared library: [libopencv_highgui.so.4.5d]
 0x0000000000000001 (NEEDED)             Shared library: [libopencv_datasets.so.4.5d]
 0x0000000000000001 (NEEDED)             Shared library: [libopencv_plot.so.4.5d]
 0x0000000000000001 (NEEDED)             Shared library: [libopencv_text.so.4.5d]
 0x0000000000000001 (NEEDED)             Shared library: [libopencv_ml.so.4.5d]
 0x0000000000000001 (NEEDED)             Shared library: [libopencv_videostab.so.4.5d]
 0x0000000000000001 (NEEDED)             Shared library: [libopencv_videoio.so.4.5d]
 0x0000000000000001 (NEEDED)             Shared library: [libopencv_viz.so.4.5d]
 0x0000000000000001 (NEEDED)             Shared library: [libopencv_wechat_qrcode.so.4.5d]
 0x0000000000000001 (NEEDED)             Shared library: [libopencv_ximgproc.so.4.5d]
 0x0000000000000001 (NEEDED)             Shared library: [libopencv_video.so.4.5d]
 0x0000000000000001 (NEEDED)             Shared library: [libopencv_xobjdetect.so.4.5d]
 0x0000000000000001 (NEEDED)             Shared library: [libopencv_imgcodecs.so.4.5d]
 0x0000000000000001 (NEEDED)             Shared library: [libopencv_objdetect.so.4.5d]
 0x0000000000000001 (NEEDED)             Shared library: [libopencv_calib3d.so.4.5d]
 0x0000000000000001 (NEEDED)             Shared library: [libopencv_dnn.so.4.5d]
 0x0000000000000001 (NEEDED)             Shared library: [libopencv_features2d.so.4.5d]
 0x0000000000000001 (NEEDED)             Shared library: [libopencv_flann.so.4.5d]
 0x0000000000000001 (NEEDED)             Shared library: [libopencv_xphoto.so.4.5d]
 0x0000000000000001 (NEEDED)             Shared library: [libopencv_photo.so.4.5d]
 0x0000000000000001 (NEEDED)             Shared library: [libopencv_imgproc.so.4.5d]
 0x0000000000000001 (NEEDED)             Shared library: [libopencv_core.so.4.5d]
 0x0000000000000001 (NEEDED)             Shared library: [libavcodec.so.58]
 0x0000000000000001 (NEEDED)             Shared library: [libavformat.so.58]
 0x0000000000000001 (NEEDED)             Shared library: [libavutil.so.56]
 0x0000000000000001 (NEEDED)             Shared library: [libswscale.so.5]
 0x0000000000000001 (NEEDED)             Shared library: [libsndfile.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libstdc++.so.6]
 0x0000000000000001 (NEEDED)             Shared library: [libm.so.6]
 0x0000000000000001 (NEEDED)             Shared library: [libgcc_s.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]

```