### PR TITLE
runpath - OpenMP temp fix

### DIFF
--- a/rocAL_pybind/CMakeLists.txt
+++ b/rocAL_pybind/CMakeLists.txt
@@ -211,8 +211,9 @@ if(${BUILD_ROCAL_PYBIND})
     # half
     include_directories(${HALF_INCLUDE_DIRS})
     # OpenMP
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
-    set(LINK_LIBRARY_LIST ${LINK_LIBRARY_LIST} OpenMP::OpenMP_CXX)
+    #set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
+    set(LINK_LIBRARY_LIST ${LINK_LIBRARY_LIST} ${OpenMP_CXX_LIBRARIES})
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wl,-rpath='$ORIGIN:$ORIGIN/llvm/lib'")
 
     file(GLOB_RECURSE pyfiles amd/*.py)
     file(GLOB_RECURSE sources *.cpp)


### PR DESCRIPTION
## Motivation

OpenMP link creates an unsafe runpath -- temp fix for mainline till the issue is resolved with OpenMP -- enable rocAL on RHEL 10

## Technical Details

Linking AMD OpenMP to any downstream application creates a runpath which has relative path
### Problem
Relative runpaths are deemed unsafe and fails packaging in RHEL 10 or newer
 ```
ERROR   0010: file '/opt/rocm/lib/librpp.so.2.0.0' contains an empty runpath in [:/opt/rocm-6.5.0/lib/llvm/bin/../lib]
ERROR   0020: file '/opt/rocm/lib/librpp.so.2.0.0' contains a runpath referencing '..' of an absolute path [:/opt/rocm-6.5.0/lib/llvm/bin/../lib]
error: Bad exit status from /var/tmp/rpm-tmp.LmQSKp (%install)
    Bad exit status from /var/tmp/rpm-tmp.LmQSKp (%install)
```
### Fix for a similar issue in LLVM / AMD LLVM
https://github.com/llvm/llvm-project/pull/143792 
### Reproduce issue using AMD OpenMP sample
https://rocm.docs.amd.com/projects/llvm-project/en/latest/conceptual/openmp.html#ompt-target-support 
 ```
cd $ROCM_PATH/share/openmp-extras/examples/tools/ompt/veccopy-ompt-target-tracing
sudo make run
readelf -d veccopy-ompt-target-tracing
 ```
### Output
 
```
readelf -d veccopy-ompt-target-tracing
 
Dynamic section at offset 0x5ae8 contains 27 entries:
  Tag        Type                         Name/Value
0x000000000000001d (RUNPATH)            Library runpath: [/opt/rocm-7.1.0/lib/llvm/bin/../lib:/opt/rocm-7.1.0/lib/llvm/bin/../../../lib]
```
## Test Plan

Build in RHEL 10

## Test Result

rocAL Package created using RPM

## Submission Checklist

- [X ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
