### PR TITLE
rocAL DecoderType enum change

### DIFF
--- a/rocAL/include/decoders/audio/audio_decoder_factory.hpp
+++ b/rocAL/include/decoders/audio/audio_decoder_factory.hpp
@@ -28,7 +28,7 @@ THE SOFTWARE.
 #ifdef ROCAL_AUDIO
 static std::shared_ptr<AudioDecoder> create_audio_decoder(DecoderConfig config) {
     switch (config.type()) {
-        case DecoderType::AUDIO_SOFTWARE_DECODE:
+        case DecoderType::AUDIO_SOFTWARE:
             return std::make_shared<GenericAudioDecoder>();
         default:
             THROW("Unsupported decoder type " + TOSTR(config.type()));

--- a/rocAL/include/decoders/image/decoder.h
+++ b/rocAL/include/decoders/image/decoder.h
@@ -42,12 +42,12 @@ THE SOFTWARE.
 enum class DecoderType {
     TURBO_JPEG = 0,        //!< Can only decode
     FUSED_TURBO_JPEG = 1,  //!< FOR PARTIAL DECODING
-    OPENCV_DEC = 2,        //!< for back_up decoding
+    OPENCV = 2,            //!< for back_up decoding
     SKIP_DECODE = 3,       //!< For skipping decoding in case of uncompressed data from reader
-    FFMPEG_SW_DECODE = 4,   //!< for video decoding using CPU and FFMPEG
-    ROCDEC_VIDEO_DECODE = 5, //!< for video decoding using HW via rocDecode
-    AUDIO_SOFTWARE_DECODE = 6,  //!< Uses sndfile to decode audio files
-    ROCJPEG_DEC = 7             //!< rocJpeg hardware decoder for decoding jpeg files
+    FFMPEG_VIDEO = 4,      //!< for video decoding using CPU and FFMPEG
+    ROCDECODE_VIDEO = 5,   //!< for video decoding using HW via rocDecode
+    AUDIO_SOFTWARE = 6,    //!< Uses sndfile to decode audio files
+    ROCJPEG = 7            //!< rocJpeg hardware decoder for decoding jpeg files
 };
 
 class DecoderConfig {

--- a/rocAL/include/decoders/image/decoder.h
+++ b/rocAL/include/decoders/image/decoder.h
@@ -159,7 +159,7 @@ class Decoder {
     virtual ~Decoder() = default;
     virtual void initialize(int device_id) = 0;
     virtual void initialize(int device_id, unsigned batch_size) { THROW("Initialize not implemented") }
-    virtual bool is_partial_decoder() = 0;
+    virtual bool is_cropped_decoder() = 0;
     virtual void set_bbox_coords(std::vector<float> bbox_coords) = 0;
     virtual std::vector<float> get_bbox_coords() = 0;
     virtual void set_crop_window(CropWindow &crop_window) = 0;

--- a/rocAL/include/decoders/image/decoder.h
+++ b/rocAL/include/decoders/image/decoder.h
@@ -42,7 +42,7 @@ enum class DecoderType {
     FFMPEG_VIDEO = 4,      //!< for video decoding using CPU and FFMPEG
     ROCDECODE_VIDEO = 5,   //!< for video decoding using HW via rocDecode
     AUDIO_SOFTWARE = 6,    //!< Uses sndfile to decode audio files
-    ROCJPEG = 7            //!< rocJpeg hardware decoder for decoding jpeg files
+    ROCJPEG = 7,           //!< rocJpeg hardware decoder for decoding jpeg files
     ROCJPEG_CROPPED = 8    //!< For partial decoding of jpeg files using rocJpeg hardware decoder 
 };
 

--- a/rocAL/include/decoders/image/fused_crop_decoder.h
+++ b/rocAL/include/decoders/image/fused_crop_decoder.h
@@ -55,14 +55,14 @@ class FusedCropTJDecoder : public Decoder {
 
     ~FusedCropTJDecoder() override;
     void initialize(int device_id) override{};
-    bool is_partial_decoder() override { return _is_partial_decoder; }
+    bool is_cropped_decoder() override { return _is_cropped_decoder; }
     void set_bbox_coords(std::vector<float> bbox_coord) override { _bbox_coord = bbox_coord; }
     std::vector<float> get_bbox_coords() override { return _bbox_coord; }
     void set_crop_window(CropWindow &crop_window) override { _crop_window = crop_window; }
 
    private:
     tjhandle m_jpegDecompressor;
-    bool _is_partial_decoder = true;
+    bool _is_cropped_decoder = true;
     std::vector<float> _bbox_coord;
     CropWindow _crop_window;
 };

--- a/rocAL/include/decoders/image/open_cv_decoder.h
+++ b/rocAL/include/decoders/image/open_cv_decoder.h
@@ -63,7 +63,7 @@ class CVDecoder : public Decoder {
                   size_t &actual_decoded_width, size_t &actual_decoded_height,
                   Decoder::ColorFormat desired_decoded_color_format, DecoderConfig config, bool keep_original_size = false) override;
 
-    bool is_partial_decoder() override { return _is_partial_decoder; }
+    bool is_cropped_decoder() override { return _is_cropped_decoder; }
     void set_bbox_coords(std::vector<float> bbox_coord) override { _bbox_coord = bbox_coord; }
     void set_crop_window(CropWindow &crop_window) override { _crop_window = crop_window; }
     std::vector<float> get_bbox_coords() override { return _bbox_coord; }
@@ -75,7 +75,7 @@ class CVDecoder : public Decoder {
     // cv::Mat m_mat_compressed;
     cv::Mat m_mat_scaled;
     cv::Mat m_mat_orig;
-    bool _is_partial_decoder = false;
+    bool _is_cropped_decoder = false;
     std::vector<float> _bbox_coord;
     CropWindow _crop_window;
 };

--- a/rocAL/include/decoders/image/rocjpeg_decoder.h
+++ b/rocAL/include/decoders/image/rocjpeg_decoder.h
@@ -88,12 +88,12 @@ class HWRocJpegDecoder : public Decoder {
     ~HWRocJpegDecoder() override;
     void initialize(int device_id) override {}
     void initialize(int device_id, unsigned batch_size) override;
-    bool is_partial_decoder() override { return _is_partial_decoder; }
+    bool is_cropped_decoder() override { return _is_cropped_decoder; }
     void set_bbox_coords(std::vector<float> bbox_coord) override { _bbox_coord = bbox_coord; }
     std::vector<float> get_bbox_coords() override { return _bbox_coord; }
     void set_crop_window(CropWindow &crop_window) override { _crop_window = crop_window; }
    private:
-    bool _is_partial_decoder = true;
+    bool _is_cropped_decoder = true;
     std::vector<float> _bbox_coord;
     CropWindow _crop_window;
     RocJpegHandle _rocjpeg_handle;

--- a/rocAL/include/decoders/image/turbo_jpeg_decoder.h
+++ b/rocAL/include/decoders/image/turbo_jpeg_decoder.h
@@ -57,7 +57,7 @@ class TJDecoder : public Decoder {
 
     ~TJDecoder() override;
     void initialize(int device_id) override{};
-    bool is_partial_decoder() override { return _is_partial_decoder; }
+    bool is_cropped_decoder() override { return _is_cropped_decoder; }
     void set_bbox_coords(std::vector<float> bbox_coord) override { _bbox_coord = bbox_coord; }
     void set_crop_window(CropWindow &crop_window) override { _crop_window = crop_window; }
     std::vector<float> get_bbox_coords() override { return _bbox_coord; }
@@ -66,7 +66,7 @@ class TJDecoder : public Decoder {
     tjhandle m_jpegDecompressor;
     tjscalingfactor *_scaling_factors = nullptr;
     int _num_scaling_factors = 0;
-    bool _is_partial_decoder = false;
+    bool _is_cropped_decoder = false;
     std::vector<float> _bbox_coord;
     const static unsigned _max_scaling_factor = 8;
     CropWindow _crop_window;

--- a/rocAL/source/api/rocal_api_data_loaders.cpp
+++ b/rocAL/source/api/rocal_api_data_loaders.cpp
@@ -168,9 +168,9 @@ auto convert_decoder_mode = [](RocalDecodeDevice decode_mode) {
 auto convert_video_decoder_type = [](RocalDecoderType decoder_type) {
     switch (decoder_type) {
         case ROCAL_DECODER_VIDEO_FFMPEG_SW:
-            return DecoderType::FFMPEG_SW_DECODE;
+            return DecoderType::FFMPEG_VIDEO;
         case ROCAL_DECODER_VIDEO_ROCDECODE:
-            return DecoderType::ROCDEC_VIDEO_DECODE;
+            return DecoderType::ROCDECODE_VIDEO;
         default:
             THROW("Unsupported video decoder type" + TOSTR(decoder_type))
     }
@@ -210,8 +210,8 @@ rocalJpegFileSourceSingleShard(
         bool use_input_dimension = (decode_size_policy == ROCAL_USE_USER_GIVEN_SIZE) || (decode_size_policy == ROCAL_USE_USER_GIVEN_SIZE_RESTRICTED);
         bool decoder_keep_original = (decode_size_policy == ROCAL_USE_USER_GIVEN_SIZE_RESTRICTED) || (decode_size_policy == ROCAL_USE_MAX_SIZE_RESTRICTED);
         DecoderType decType = DecoderType::TURBO_JPEG;  // default
-        if (dec_type == ROCAL_DECODER_OPENCV) decType = DecoderType::OPENCV_DEC;
-        if (dec_type == ROCAL_DECODER_ROCJPEG) decType = DecoderType::ROCJPEG_DEC;
+        if (dec_type == ROCAL_DECODER_OPENCV) decType = DecoderType::OPENCV;
+        if (dec_type == ROCAL_DECODER_ROCJPEG) decType = DecoderType::ROCJPEG;
 
         if (shard_count < 1)
             THROW("Shard count should be bigger than 0")
@@ -271,8 +271,8 @@ rocalJpegFileSource(
         bool use_input_dimension = (decode_size_policy == ROCAL_USE_USER_GIVEN_SIZE) || (decode_size_policy == ROCAL_USE_USER_GIVEN_SIZE_RESTRICTED);
         bool decoder_keep_original = (decode_size_policy == ROCAL_USE_USER_GIVEN_SIZE_RESTRICTED) || (decode_size_policy == ROCAL_USE_MAX_SIZE_RESTRICTED);
         DecoderType decType = DecoderType::TURBO_JPEG;  // default
-        if (dec_type == ROCAL_DECODER_OPENCV) decType = DecoderType::OPENCV_DEC;
-        if (dec_type == ROCAL_DECODER_ROCJPEG) decType = DecoderType::ROCJPEG_DEC;
+        if (dec_type == ROCAL_DECODER_OPENCV) decType = DecoderType::OPENCV;
+        if (dec_type == ROCAL_DECODER_ROCJPEG) decType = DecoderType::ROCJPEG;
 
         if (internal_shard_count < 1)
             THROW("Shard count should be bigger than 0")
@@ -462,8 +462,8 @@ rocalJpegCaffe2LMDBRecordSource(
         bool use_input_dimension = (decode_size_policy == ROCAL_USE_USER_GIVEN_SIZE) || (decode_size_policy == ROCAL_USE_USER_GIVEN_SIZE_RESTRICTED);
         bool decoder_keep_original = (decode_size_policy == ROCAL_USE_USER_GIVEN_SIZE_RESTRICTED) || (decode_size_policy == ROCAL_USE_MAX_SIZE_RESTRICTED);
         DecoderType decType = DecoderType::TURBO_JPEG;  // default
-        if (dec_type == ROCAL_DECODER_OPENCV) decType = DecoderType::OPENCV_DEC;
-        if (dec_type == ROCAL_DECODER_ROCJPEG) decType = DecoderType::ROCJPEG_DEC;
+        if (dec_type == ROCAL_DECODER_OPENCV) decType = DecoderType::OPENCV;
+        if (dec_type == ROCAL_DECODER_ROCJPEG) decType = DecoderType::ROCJPEG;
 
         if (internal_shard_count < 1)
             THROW("internal shard count should be bigger than 0")
@@ -521,8 +521,8 @@ rocalJpegCaffe2LMDBRecordSourceSingleShard(
         bool use_input_dimension = (decode_size_policy == ROCAL_USE_USER_GIVEN_SIZE) || (decode_size_policy == ROCAL_USE_USER_GIVEN_SIZE_RESTRICTED);
         bool decoder_keep_original = (decode_size_policy == ROCAL_USE_USER_GIVEN_SIZE_RESTRICTED) || (decode_size_policy == ROCAL_USE_MAX_SIZE_RESTRICTED);
         DecoderType decType = DecoderType::TURBO_JPEG;  // default
-        if (dec_type == ROCAL_DECODER_OPENCV) decType = DecoderType::OPENCV_DEC;
-        if (dec_type == ROCAL_DECODER_ROCJPEG) decType = DecoderType::ROCJPEG_DEC;
+        if (dec_type == ROCAL_DECODER_OPENCV) decType = DecoderType::OPENCV;
+        if (dec_type == ROCAL_DECODER_ROCJPEG) decType = DecoderType::ROCJPEG;
 
         if (shard_count < 1)
             THROW("Shard count should be bigger than 0")
@@ -583,8 +583,8 @@ rocalJpegCaffeLMDBRecordSource(
         bool use_input_dimension = (decode_size_policy == ROCAL_USE_USER_GIVEN_SIZE) || (decode_size_policy == ROCAL_USE_USER_GIVEN_SIZE_RESTRICTED);
         bool decoder_keep_original = (decode_size_policy == ROCAL_USE_USER_GIVEN_SIZE_RESTRICTED) || (decode_size_policy == ROCAL_USE_MAX_SIZE_RESTRICTED);
         DecoderType decType = DecoderType::TURBO_JPEG;  // default
-        if (dec_type == ROCAL_DECODER_OPENCV) decType = DecoderType::OPENCV_DEC;
-        if (dec_type == ROCAL_DECODER_ROCJPEG) decType = DecoderType::ROCJPEG_DEC;
+        if (dec_type == ROCAL_DECODER_OPENCV) decType = DecoderType::OPENCV;
+        if (dec_type == ROCAL_DECODER_ROCJPEG) decType = DecoderType::ROCJPEG;
 
         if (internal_shard_count < 1)
             THROW("internal shard count should be bigger than 0")
@@ -644,8 +644,8 @@ rocalJpegCaffeLMDBRecordSourceSingleShard(
         bool use_input_dimension = (decode_size_policy == ROCAL_USE_USER_GIVEN_SIZE) || (decode_size_policy == ROCAL_USE_USER_GIVEN_SIZE_RESTRICTED);
         bool decoder_keep_original = (decode_size_policy == ROCAL_USE_USER_GIVEN_SIZE_RESTRICTED) || (decode_size_policy == ROCAL_USE_MAX_SIZE_RESTRICTED);
         DecoderType decType = DecoderType::TURBO_JPEG;  // default
-        if (dec_type == ROCAL_DECODER_OPENCV) decType = DecoderType::OPENCV_DEC;
-        if (dec_type == ROCAL_DECODER_ROCJPEG) decType = DecoderType::ROCJPEG_DEC;
+        if (dec_type == ROCAL_DECODER_OPENCV) decType = DecoderType::OPENCV;
+        if (dec_type == ROCAL_DECODER_ROCJPEG) decType = DecoderType::ROCJPEG;
 
         if (shard_count < 1)
             THROW("Shard count should be bigger than 0")
@@ -830,8 +830,8 @@ rocalMXNetRecordSource(
         bool use_input_dimension = (decode_size_policy == ROCAL_USE_USER_GIVEN_SIZE) || (decode_size_policy == ROCAL_USE_USER_GIVEN_SIZE_RESTRICTED);
         bool decoder_keep_original = (decode_size_policy == ROCAL_USE_USER_GIVEN_SIZE_RESTRICTED) || (decode_size_policy == ROCAL_USE_MAX_SIZE_RESTRICTED);
         DecoderType decType = DecoderType::TURBO_JPEG;  // default
-        if (dec_type == ROCAL_DECODER_OPENCV) decType = DecoderType::OPENCV_DEC;
-        if (dec_type == ROCAL_DECODER_ROCJPEG) decType = DecoderType::ROCJPEG_DEC;
+        if (dec_type == ROCAL_DECODER_OPENCV) decType = DecoderType::OPENCV;
+        if (dec_type == ROCAL_DECODER_ROCJPEG) decType = DecoderType::ROCJPEG;
 
         if (internal_shard_count < 1)
             THROW("internal shard count should be bigger than 0")
@@ -892,8 +892,8 @@ rocalMXNetRecordSourceSingleShard(
         bool use_input_dimension = (decode_size_policy == ROCAL_USE_USER_GIVEN_SIZE) || (decode_size_policy == ROCAL_USE_USER_GIVEN_SIZE_RESTRICTED);
         bool decoder_keep_original = (decode_size_policy == ROCAL_USE_USER_GIVEN_SIZE_RESTRICTED) || (decode_size_policy == ROCAL_USE_MAX_SIZE_RESTRICTED);
         DecoderType decType = DecoderType::TURBO_JPEG;  // default
-        if (dec_type == ROCAL_DECODER_OPENCV) decType = DecoderType::OPENCV_DEC;
-        if (dec_type == ROCAL_DECODER_ROCJPEG) decType = DecoderType::ROCJPEG_DEC;
+        if (dec_type == ROCAL_DECODER_OPENCV) decType = DecoderType::OPENCV;
+        if (dec_type == ROCAL_DECODER_ROCJPEG) decType = DecoderType::ROCJPEG;
 
         if (shard_count < 1)
             THROW("Shard count should be bigger than 0")
@@ -955,8 +955,8 @@ rocalJpegCOCOFileSource(
         bool use_input_dimension = (decode_size_policy == ROCAL_USE_USER_GIVEN_SIZE) || (decode_size_policy == ROCAL_USE_USER_GIVEN_SIZE_RESTRICTED);
         bool decoder_keep_original = (decode_size_policy == ROCAL_USE_USER_GIVEN_SIZE_RESTRICTED) || (decode_size_policy == ROCAL_USE_MAX_SIZE_RESTRICTED);
         DecoderType decType = DecoderType::TURBO_JPEG;  // default
-        if (dec_type == ROCAL_DECODER_OPENCV) decType = DecoderType::OPENCV_DEC;
-        if (dec_type == ROCAL_DECODER_ROCJPEG) decType = DecoderType::ROCJPEG_DEC;
+        if (dec_type == ROCAL_DECODER_OPENCV) decType = DecoderType::OPENCV;
+        if (dec_type == ROCAL_DECODER_ROCJPEG) decType = DecoderType::ROCJPEG;
 
         if (internal_shard_count < 1)
             THROW("Shard count should be bigger than 0")
@@ -1018,8 +1018,8 @@ rocalJpegCOCOFileSourceSingleShard(
         bool use_input_dimension = (decode_size_policy == ROCAL_USE_USER_GIVEN_SIZE) || (decode_size_policy == ROCAL_USE_USER_GIVEN_SIZE_RESTRICTED);
         bool decoder_keep_original = (decode_size_policy == ROCAL_USE_USER_GIVEN_SIZE_RESTRICTED) || (decode_size_policy == ROCAL_USE_MAX_SIZE_RESTRICTED);
         DecoderType decType = DecoderType::TURBO_JPEG;  // default
-        if (dec_type == ROCAL_DECODER_OPENCV) decType = DecoderType::OPENCV_DEC;
-        if (dec_type == ROCAL_DECODER_ROCJPEG) decType = DecoderType::ROCJPEG_DEC;
+        if (dec_type == ROCAL_DECODER_OPENCV) decType = DecoderType::OPENCV;
+        if (dec_type == ROCAL_DECODER_ROCJPEG) decType = DecoderType::ROCJPEG;
 
         if (shard_count < 1)
             THROW("Shard count should be bigger than 0")
@@ -1267,8 +1267,8 @@ rocalJpegTFRecordSource(
         };
         bool use_input_dimension = (decode_size_policy == ROCAL_USE_USER_GIVEN_SIZE) || (decode_size_policy == ROCAL_USE_USER_GIVEN_SIZE_RESTRICTED);
         DecoderType decType = DecoderType::TURBO_JPEG;  // default
-        if (dec_type == ROCAL_DECODER_OPENCV) decType = DecoderType::OPENCV_DEC;
-        if (dec_type == ROCAL_DECODER_ROCJPEG) decType = DecoderType::ROCJPEG_DEC;
+        if (dec_type == ROCAL_DECODER_OPENCV) decType = DecoderType::OPENCV;
+        if (dec_type == ROCAL_DECODER_ROCJPEG) decType = DecoderType::ROCJPEG;
 
         if (internal_shard_count < 1)
             THROW("internal shard count should be bigger than 0")
@@ -1336,8 +1336,8 @@ rocalJpegTFRecordSourceSingleShard(
         bool use_input_dimension = (decode_size_policy == ROCAL_USE_USER_GIVEN_SIZE) || (decode_size_policy == ROCAL_USE_USER_GIVEN_SIZE_RESTRICTED);
         bool decoder_keep_original = (decode_size_policy == ROCAL_USE_USER_GIVEN_SIZE_RESTRICTED) || (decode_size_policy == ROCAL_USE_MAX_SIZE_RESTRICTED);
         DecoderType decType = DecoderType::TURBO_JPEG;  // default
-        if (dec_type == ROCAL_DECODER_OPENCV) decType = DecoderType::OPENCV_DEC;
-        if (dec_type == ROCAL_DECODER_ROCJPEG) decType = DecoderType::ROCJPEG_DEC;
+        if (dec_type == ROCAL_DECODER_OPENCV) decType = DecoderType::OPENCV;
+        if (dec_type == ROCAL_DECODER_ROCJPEG) decType = DecoderType::ROCJPEG;
 
         if (shard_count < 1)
             THROW("Shard count should be bigger than 0")
@@ -2172,7 +2172,7 @@ rocalJpegExternalFileSource(
     try {
         bool decoder_keep_original = (decode_size_policy == ROCAL_USE_USER_GIVEN_SIZE_RESTRICTED) || (decode_size_policy == ROCAL_USE_MAX_SIZE_RESTRICTED);
         DecoderType decType = DecoderType::TURBO_JPEG;  // default
-        if (dec_type == ROCAL_DECODER_OPENCV) decType = DecoderType::OPENCV_DEC;
+        if (dec_type == ROCAL_DECODER_OPENCV) decType = DecoderType::OPENCV;
         if ((decode_size_policy == ROCAL_USE_MAX_SIZE) || (decode_size_policy == ROCAL_USE_MAX_SIZE_RESTRICTED))
             THROW("use_max_size is not supported in external source reader");
 
@@ -2241,7 +2241,7 @@ rocalAudioFileSourceSingleShard(
         } else {
             LOG("User input size " + TOSTR(max_decoded_samples) + " x " + TOSTR(max_decoded_channels))
         }
-        auto [max_sample_length, max_channels] = use_input_dimension ? std::make_tuple(max_decoded_samples, max_decoded_channels) : evaluate_audio_data_set(StorageType::FILE_SYSTEM, DecoderType::AUDIO_SOFTWARE_DECODE, source_path, source_file_list_path, context->master_graph->meta_data_reader());
+        auto [max_sample_length, max_channels] = use_input_dimension ? std::make_tuple(max_decoded_samples, max_decoded_channels) : evaluate_audio_data_set(StorageType::FILE_SYSTEM, DecoderType::AUDIO_SOFTWARE, source_path, source_file_list_path, context->master_graph->meta_data_reader());
         INFO("Internal buffer size for audio samples = " + TOSTR(max_sample_length) + " and channels = " + TOSTR(max_channels))
         RocalTensorDataType tensor_data_type = RocalTensorDataType::FP32;
         std::vector<size_t> dims = {context->user_batch_size(), max_sample_length, max_channels};
@@ -2253,7 +2253,7 @@ rocalAudioFileSourceSingleShard(
         output->reset_audio_sample_rate();
         auto cpu_num_threads = context->master_graph->calculate_cpu_num_threads(shard_count);
         ShardingInfo sharding_info(convert_last_batch_policy(rocal_sharding_info.last_batch_policy), rocal_sharding_info.pad_last_batch_repeated, rocal_sharding_info.stick_to_shard, rocal_sharding_info.shard_size);
-        context->master_graph->add_node<AudioLoaderSingleShardNode>({}, {output})->Init(shard_id, shard_count, cpu_num_threads, source_path, source_file_list_path, StorageType::FILE_SYSTEM, DecoderType::AUDIO_SOFTWARE_DECODE, shuffle, loop, context->user_batch_size(), context->master_graph->mem_type(), context->master_graph->meta_data_reader(), sharding_info);
+        context->master_graph->add_node<AudioLoaderSingleShardNode>({}, {output})->Init(shard_id, shard_count, cpu_num_threads, source_path, source_file_list_path, StorageType::FILE_SYSTEM, DecoderType::AUDIO_SOFTWARE, shuffle, loop, context->user_batch_size(), context->master_graph->mem_type(), context->master_graph->meta_data_reader(), sharding_info);
         context->master_graph->set_loop(loop);
         if (downmix && (max_channels > 1)) {
             TensorInfo output_info = info;
@@ -2305,7 +2305,7 @@ rocalAudioFileSource(
         } else {
             LOG("User input size " + TOSTR(max_decoded_samples) + " x " + TOSTR(max_decoded_channels))
         }
-        auto [max_sample_length, max_channels] = use_input_dimension ? std::make_tuple(max_decoded_samples, max_decoded_channels) : evaluate_audio_data_set(StorageType::FILE_SYSTEM, DecoderType::AUDIO_SOFTWARE_DECODE, source_path, source_file_list_path, context->master_graph->meta_data_reader());
+        auto [max_sample_length, max_channels] = use_input_dimension ? std::make_tuple(max_decoded_samples, max_decoded_channels) : evaluate_audio_data_set(StorageType::FILE_SYSTEM, DecoderType::AUDIO_SOFTWARE, source_path, source_file_list_path, context->master_graph->meta_data_reader());
         INFO("Internal buffer size for audio samples = " + TOSTR(max_sample_length) + " and channels = " + TOSTR(max_channels))
         RocalTensorDataType tensor_data_type = RocalTensorDataType::FP32;
         std::vector<size_t> dims = {context->user_batch_size(), max_sample_length, max_channels};
@@ -2320,7 +2320,7 @@ rocalAudioFileSource(
             THROW("internal shard count should be bigger than 0")
         ShardingInfo sharding_info(convert_last_batch_policy(rocal_sharding_info.last_batch_policy), rocal_sharding_info.pad_last_batch_repeated, rocal_sharding_info.stick_to_shard, rocal_sharding_info.shard_size);
         auto cpu_num_threads = context->master_graph->calculate_cpu_num_threads(shard_count);
-        context->master_graph->add_node<AudioLoaderNode>({}, {output})->Init(shard_count, cpu_num_threads, source_path, source_file_list_path, StorageType::FILE_SYSTEM, DecoderType::AUDIO_SOFTWARE_DECODE, shuffle, loop, context->user_batch_size(), context->master_graph->mem_type(), context->master_graph->meta_data_reader(), sharding_info);
+        context->master_graph->add_node<AudioLoaderNode>({}, {output})->Init(shard_count, cpu_num_threads, source_path, source_file_list_path, StorageType::FILE_SYSTEM, DecoderType::AUDIO_SOFTWARE, shuffle, loop, context->user_batch_size(), context->master_graph->mem_type(), context->master_graph->meta_data_reader(), sharding_info);
         context->master_graph->set_loop(loop);
         if (downmix && (max_channels > 1)) {
             TensorInfo output_info = info;
@@ -2370,7 +2370,7 @@ rocalWebDatasetSourceSingleShard(
         bool decoder_keep_original = (decode_size_policy == ROCAL_USE_USER_GIVEN_SIZE_RESTRICTED) || (decode_size_policy == ROCAL_USE_MAX_SIZE_RESTRICTED);
         DecoderType decType = DecoderType::TURBO_JPEG;  // default
         if (dec_type == ROCAL_DECODER_OPENCV) {
-            decType = DecoderType::OPENCV_DEC;
+            decType = DecoderType::OPENCV;
         }
 
         if (shard_count < 1) {

--- a/rocAL/source/decoders/image/decoder_factory.cpp
+++ b/rocAL/source/decoders/image/decoder_factory.cpp
@@ -39,12 +39,12 @@ std::shared_ptr<Decoder> create_decoder(DecoderConfig config) {
             return std::make_shared<FusedCropTJDecoder>();
             break;
 #if ENABLE_OPENCV
-        case DecoderType::OPENCV_DEC:
+        case DecoderType::OPENCV:
             return std::make_shared<CVDecoder>();
             break;
 #endif
 #if ENABLE_ROCJPEG
-        case DecoderType::ROCJPEG_DEC:
+        case DecoderType::ROCJPEG:
             return std::make_shared<HWRocJpegDecoder>(config.get_hip_stream());
             break;
 #endif

--- a/rocAL/source/decoders/video/video_decoder_factory.cpp
+++ b/rocAL/source/decoders/video/video_decoder_factory.cpp
@@ -30,10 +30,10 @@ THE SOFTWARE.
 #ifdef ROCAL_VIDEO
 std::shared_ptr<VideoDecoder> create_video_decoder(DecoderConfig config) {
     switch (config.type()) {
-        case DecoderType::FFMPEG_SW_DECODE:
+        case DecoderType::FFMPEG_VIDEO:
             return std::make_shared<FFmpegVideoDecoder>();
 #if ENABLE_ROCDECODE
-        case DecoderType::ROCDEC_VIDEO_DECODE:
+        case DecoderType::ROCDECODE_VIDEO:
             return std::make_shared<RocDecVideoDecoder>(config.get_hip_stream());
 #endif
         default:

--- a/rocAL/source/loaders/image/image_loader.cpp
+++ b/rocAL/source/loaders/image/image_loader.cpp
@@ -146,7 +146,7 @@ void ImageLoader::initialize(ReaderConfig reader_cfg, DecoderConfig decoder_cfg,
     int device_id = reader_cfg.get_shard_id();
 #if ENABLE_HIP
     // Set stream in decoder config, to be used by rocJpeg decoder for scaling
-    if (decoder_cfg._type == DecoderType::ROCJPEG_DEC) {
+    if (decoder_cfg._type == DecoderType::ROCJPEG) {
         decoder_cfg.set_hip_stream(_hip_stream);
     }
 #endif
@@ -168,7 +168,7 @@ void ImageLoader::initialize(ReaderConfig reader_cfg, DecoderConfig decoder_cfg,
     _decoded_data_info._original_height.resize(_batch_size);
     _decoded_data_info._original_width.resize(_batch_size);
     _crop_image_info._crop_image_coords.resize(_batch_size);
-    if (decoder_cfg._type == DecoderType::ROCJPEG_DEC) {
+    if (decoder_cfg._type == DecoderType::ROCJPEG) {
         // Initialize circular buffer with HIP memory for rocJPEG hardware decoder
         _circ_buff.init(_mem_type, _output_mem_size, _prefetch_queue_depth, true);
     } else {

--- a/rocAL/source/loaders/image/image_read_and_decode.cpp
+++ b/rocAL/source/loaders/image/image_read_and_decode.cpp
@@ -321,7 +321,7 @@ ImageReadAndDecode::load(unsigned char *buff,
                 _original_width[i] = original_width;
                 // decode the image and get the actual decoded image width and height
                 size_t scaledw, scaledh;
-                if (_decoder[i]->is_partial_decoder()) {
+                if (_decoder[i]->is_cropped_decoder()) {
                     if (_randombboxcrop_meta_data_reader) {
                         _decoder[i]->set_bbox_coords(_bbox_coords[i]);
                     } else if (_random_crop_dec_param) {

--- a/rocAL/source/loaders/image/image_read_and_decode.cpp
+++ b/rocAL/source/loaders/image/image_read_and_decode.cpp
@@ -381,7 +381,7 @@ ImageReadAndDecode::load(unsigned char *buff,
                 _actual_decoded_width[i] = decoded_width;
                 _actual_decoded_height[i] = decoded_height;
 
-                if (_rocjpeg_decoder->is_partial_decoder()) {
+                if (_rocjpeg_decoder->is_cropped_decoder()) {
                     if (_randombboxcrop_meta_data_reader) {
                         _rocjpeg_decoder->set_bbox_coords(_bbox_coords[i]);
                     } else if (_random_crop_dec_param) {

--- a/rocAL/source/loaders/image/image_read_and_decode.cpp
+++ b/rocAL/source/loaders/image/image_read_and_decode.cpp
@@ -87,7 +87,7 @@ void ImageReadAndDecode::create(ReaderConfig reader_config, DecoderConfig decode
         _random_crop_dec_param = std::make_shared<RocalRandomCropDecParam>(aspect_ratio_range, area_range, decoder_config.get_num_attempts(), _batch_size);
     }
     if ((_decoder_config._type != DecoderType::SKIP_DECODE)) {
-        if (_decoder_config._type == DecoderType::ROCJPEG_DEC) {
+        if (_decoder_config._type == DecoderType::ROCJPEG) {
             for (int i = 0; i < batch_size; i++) {
                 _compressed_buff[i].resize(MAX_COMPRESSED_SIZE);  // If we don't need MAX_COMPRESSED_SIZE we can remove this & resize in load module
             }
@@ -290,7 +290,7 @@ ImageReadAndDecode::load(unsigned char *buff,
         for (size_t i = 0; i < _batch_size; i++)
             _decompressed_buff_ptrs[i] = buff + image_size * i;
 
-        if (_decoder_config._type != DecoderType::ROCJPEG_DEC) {
+        if (_decoder_config._type != DecoderType::ROCJPEG) {
 #pragma omp parallel for num_threads(_num_threads)
             for (size_t i = 0; i < _batch_size; i++) {
                 // initialize the actual decoded height and width with the maximum
@@ -339,7 +339,7 @@ ImageReadAndDecode::load(unsigned char *buff,
                 _actual_decoded_width[i] = scaledw;
                 _actual_decoded_height[i] = scaledh;
             }
-        } else if (_decoder_config._type == DecoderType::ROCJPEG_DEC) {
+        } else if (_decoder_config._type == DecoderType::ROCJPEG) {
 #if ENABLE_HIP
             // Set device ID for load routine thread once
             if (!_set_device_id) {

--- a/rocAL/source/loaders/video/video_loader.cpp
+++ b/rocAL/source/loaders/video/video_loader.cpp
@@ -134,7 +134,7 @@ void VideoLoader::initialize(ReaderConfig reader_cfg, DecoderConfig decoder_cfg,
     _decoder_keep_original = decoder_keep_original;
     _video_loader = std::make_shared<VideoReadAndDecode>();
 #if ENABLE_HIP
-    if (decoder_cfg._type == DecoderType::ROCDEC_VIDEO_DECODE) {
+    if (decoder_cfg._type == DecoderType::ROCDECODE_VIDEO) {
         decoder_cfg.set_hip_stream(_hip_stream);
     }
 #endif
@@ -152,7 +152,7 @@ void VideoLoader::initialize(ReaderConfig reader_cfg, DecoderConfig decoder_cfg,
     _decoded_data_info._original_height.resize(_batch_size);
     _decoded_data_info._original_width.resize(_batch_size);
     _circ_buff.init(_mem_type, _output_mem_size, _prefetch_queue_depth, 
-                    decoder_cfg._type == DecoderType::ROCDEC_VIDEO_DECODE ? true : false);  // Use HIP memory for rocDecode
+                    decoder_cfg._type == DecoderType::ROCDECODE_VIDEO ? true : false);  // Use HIP memory for rocDecode
     _is_initialized = true;
     LOG("Loader module initialized");
 }


### PR DESCRIPTION
## Motivation

- Modify the DecoderType enum values to remove the trailing _DEC suffix as suggested in PR #368 
- Change the name of the function from is_partial_decoder() to is_cropped_decoder

## Test Plan

No new tests added