### PR TITLE
removing SP6

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ rocAL can be currently used to perform the following operations either with rand
 * Linux distribution
   + Ubuntu - `22.04` / `24.04`
   + RedHat - `8` / `9`
-  + SLES - `15 SP6` / `15 SP7`
+  + SLES - `15 SP7`
 
 ### Hardware
 

--- a/docs/install/rocAL-prerequisites.rst
+++ b/docs/install/rocAL-prerequisites.rst
@@ -14,7 +14,7 @@ rocAL has been tested on the following Linux environments:
   
 * Ubuntu 22.04 and 24.04
 * RHEL 8 and 9
-* SLES 15 SP6 and SP7
+* SLES 15 SP7
 
 See `Supported operating systems <https://rocm.docs.amd.com/projects/install-on-linux/en/latest/reference/system-requirements.html#supported-operating-systems>`_ for the complete list of ROCm supported Linux environments.
 


### PR DESCRIPTION
## Motivation

SLES SP6 is not supported in rocm 7.0.
