### PR TITLE
Setup - Mark turbojpeg as a source install on centos-8 based systems

### DIFF
--- a/rocAL-setup.py
+++ b/rocAL-setup.py
@@ -261,6 +261,8 @@ if "sles" in platformInfo:
     libProtoCompiler = "libprotobuf-c-devel"
     libsndFile = "cmake" # TBD - libsndfile-devel  fails to install in SLES
     libTurboJPEG = "cmake" # TBD libturbojpeg0 dev/devel package unavailable in SLES
+if "centos-8" in platformInfo:
+    libTurboJPEG = "cmake" # TurboJPEG >=2.0.0 unavailable on CentOS 8
 coreRPMPackages = [
     'nasm',
     'yasm',
@@ -342,7 +344,7 @@ else:
     ERROR_CHECK(os.system('(cd '+deps_dir+'; mkdir build )'))
 
     # turbo-JPEG - https://github.com/libjpeg-turbo/libjpeg-turbo.git -- 3.0.2
-    if "SLES" in platformInfo:
+    if ("sles" in platformInfo) or ("centos-8" in platformInfo):
         turboJpegVersion = '3.0.2'
         ERROR_CHECK(os.system(
                     '(cd '+deps_dir+'; git clone -b '+turboJpegVersion+' https://github.com/libjpeg-turbo/libjpeg-turbo.git )'))


### PR DESCRIPTION
## Motivation

Updates the python setup script to build TurboJPEG from source on CentOS 8 based systems to satisfy version requirements.

## Technical Details

## Test Plan

## Test Result

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
