### PR TITLE
readding the readme

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,1 @@
+Please see [https://rocm.docs.amd.com/projects/rocAL/en/latest/](https://rocm.docs.amd.com/projects/rocAL/en/latest/) for the official rocAL documentation.


### PR DESCRIPTION
## Motivation
The build script looks for docs/readme so I'm adding back a stub to keep the build from failing.
Not labelling this with ci-docs so that the full CI is run