### PR TITLE
rocAL-setup: fix RapidJSON build with CMake 4.x

### DIFF
--- a/rocAL-setup.py
+++ b/rocAL-setup.py
@@ -368,9 +368,10 @@ else:
         ERROR_CHECK(os.system('(cd '+deps_dir+'/dlpack; mkdir -p build && cd build; '+linuxCMake+' ..; make -j$(nproc); sudo make install)'))
 
     # RapidJSON - Source TBD: Package install of RapidJSON has compile issues - https://github.com/Tencent/rapidjson.git -- master
-    ERROR_CHECK(os.system('(cd '+deps_dir+'; git clone https://github.com/Tencent/rapidjson.git; cd rapidjson; mkdir build; cd build; ' +	
-            linuxCMake+' ../; make -j$(nproc); sudo make install)'))
-    
+    # CMake 4+ rejects cmake_minimum_required < 3.5 in some subtrees. CMAKE_POLICY_VERSION_MINIMUM floors policy version;
+    # RAPIDJSON_BUILD_* skips examples/tests/doc (faster; doc needs graphviz dot).
+    ERROR_CHECK(os.system('(cd '+deps_dir+'; git clone https://github.com/Tencent/rapidjson.git; cd rapidjson; mkdir build; cd build; ' +
+            linuxCMake+' ../ -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DRAPIDJSON_BUILD_EXAMPLES=OFF -DRAPIDJSON_BUILD_TESTS=OFF -DRAPIDJSON_BUILD_DOC=OFF; make -j$(nproc); sudo make install)'))
     # libtar - https://repo.or.cz/libtar.git ; version - v1.2.20
     libtar_version = 'v1.2.20'
     ERROR_CHECK(os.system('sudo '+linuxFlag+' '+linuxSystemInstall+' '+linuxSystemInstall_check +


### PR DESCRIPTION
## Motivation
- Configuring RapidJSON from rocAL-setup.py fails on Cmake 4.x since certain subdirectories in the RapidJSON repo still use cmake_minimum_required older than 3.5, which CMake 4 no longer accepts.
-  Building examples, tests, and documentation is unnecessary for rocAL (header-only use) and pulls in extra work and optional tooling (e.g. doc generation)

## Technical Details
- Pass CMAKE_POLICY_VERSION_MINIMUM=3.5 so CMake can treat the effective policy version as at least 3.5 when older subprojects are still configured. 
- Set RAPIDJSON_BUILD_EXAMPLES=OFF, RAPIDJSON_BUILD_TESTS=OFF, and RAPIDJSON_BUILD_DOC=OFF so we only install what rocAL needs (headers / package config), avoid optional dependencies, and shorten the install step.

## Test Plan
- Ran rocAL-setup.py with CMake 4.x and built rocAL
- Ran ctests

## Test Result
rocAL build succeeds and all ctests pass