### PR TITLE
Make LMDB an optional dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Full documentation for rocLibrary is available at [https://rocm.docs.amd.com/pro
 * Introduce `NodeFactory` for dynamic node registration and creation.
 
 ### Changes
+* LMDB is now an optional dependency. When liblmdb is present at configure time, rocAL builds with Caffe/Caffe2 LMDB reader support; otherwise it builds without it.
 * Changes build instructions to omit building of wheels.
 * Adds new public APIs rocalSerialize(), rocalGetSerializedString(), and rocalDeserialize() for serializing and deserializing pipelines.
 * Add support to store the pipeline and introduce template-based serialization functions for different parameter types to convert to protobuf format.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -225,8 +225,8 @@ endif()
 set(ROCAL_DEBIAN_PACKAGE_LIST  "hip-runtime-amd, openmp-extras-runtime, mivisionx, libturbojpeg:amd64 | libturbojpeg0")
 set(ROCAL_RPM_PACKAGE_LIST     "hip-runtime-amd, openmp-extras-runtime, mivisionx")
 # Set the dev dependent packages
-set(ROCAL_DEBIAN_DEV_PACKAGE_LIST  "half, hip-dev, openmp-extras-dev, mivisionx-dev, liblmdb-dev, libprotobuf-dev, libturbojpeg0-dev")
-set(ROCAL_RPM_DEV_PACKAGE_LIST  "half, hip-devel, openmp-extras-devel, mivisionx-devel, lmdb-devel, protobuf-devel")
+set(ROCAL_DEBIAN_DEV_PACKAGE_LIST  "half, hip-dev, openmp-extras-dev, mivisionx-dev, libprotobuf-dev, libturbojpeg0-dev")
+set(ROCAL_RPM_DEV_PACKAGE_LIST  "half, hip-devel, openmp-extras-devel, mivisionx-devel, protobuf-devel")
 
 # Add OS specific dependencies
 if (EXISTS "/etc/os-release")

--- a/README.md
+++ b/README.md
@@ -111,11 +111,6 @@ rocAL can be currently used to perform the following operations either with rand
   sudo apt install libprotobuf-dev
   ```
 
-* [LMBD Library](http://www.lmdb.tech/doc/)
-  ```shell
-  sudo apt install liblmdb-dev
-  ```
-
 * [TurboJPEG](https://libjpeg-turbo.org/) - Version `2.0` or higher
   ```shell
   sudo apt install libturbojpeg0-dev
@@ -131,6 +126,10 @@ rocAL can be currently used to perform the following operations either with rand
 * Python3 Wheel
   ```shell
   sudo apt install python3-wheel
+  ```
+* [LMDB Library](http://www.lmdb.tech/doc/) - **Optional**: needed only for Caffe/Caffe2 LMDB reader support
+  ```shell
+  sudo apt install liblmdb-dev
   ```
 
 * rocDecode - **Optional** for source install, but required for package install

--- a/rocAL-setup.py
+++ b/rocAL-setup.py
@@ -241,7 +241,7 @@ rocmRPMPackages = [
 coreDebianPackages = [
     'nasm',
     'yasm',
-    'liblmdb-dev',
+    #'liblmdb-dev',  # optional: needed for Caffe/Caffe2 LMDB reader support
     #'rapidjson-dev',
     'libsndfile1-dev', # for audio features
     'python3-dev',
@@ -266,7 +266,7 @@ if "centos-8" in platformInfo:
 coreRPMPackages = [
     'nasm',
     'yasm',
-    'lmdb-devel',
+    #'lmdb-devel',  # optional: needed for Caffe/Caffe2 LMDB reader support
     'jsoncpp-devel',
     #'rapidjson-devel',
     str(libsndFile), # for audio features

--- a/rocAL/CMakeLists.txt
+++ b/rocAL/CMakeLists.txt
@@ -175,10 +175,11 @@ if(NOT Threads_FOUND)
     set(BUILD_ROCAL false)
     message("-- ${Yellow}NOTE: rocAL library requires Threads, Not Found ${ColourReset}")
 endif()
-# LMDB
-if(NOT LMDB_FOUND)
-    set(BUILD_ROCAL false)
-    message("-- ${Yellow}NOTE: rocAL library requires LMDB, Not Found ${ColourReset}")	
+# LMDB (optional)
+if(LMDB_FOUND)
+    message("-- ${White}rocAL built with LMDB - Caffe/Caffe2 LMDB reader support enabled${ColourReset}")
+else()
+    message("-- ${Yellow}NOTE: rocAL built without LMDB - Caffe/Caffe2 LMDB readers will not be supported${ColourReset}")
 endif()
 # RapidJSON
 if(NOT RapidJSON_FOUND)
@@ -211,9 +212,11 @@ if(${BUILD_ROCAL})
     # Protobuf
     include_directories(${PROTOBUF_INCLUDE_DIRS})
     set(LINK_LIBRARY_LIST ${LINK_LIBRARY_LIST} ${PROTOBUF_LIBRARIES})
-    # LMDB
-    include_directories(${LMDB_INCLUDE_DIRS})	
-    set(LINK_LIBRARY_LIST ${LINK_LIBRARY_LIST} ${LMDB_LIBRARIES})	
+    # LMDB (optional)
+    if(LMDB_FOUND)
+        include_directories(${LMDB_INCLUDE_DIRS})
+        set(LINK_LIBRARY_LIST ${LINK_LIBRARY_LIST} ${LMDB_LIBRARIES})
+    endif()	
     # RapidJSON
     include_directories(${RapidJSON_INCLUDE_DIRS})
     # Filesystem
@@ -342,6 +345,11 @@ if(${BUILD_ROCAL})
         target_compile_definitions(${PROJECT_NAME} PUBLIC -DROCAL_AUDIO)
     else()
         message("-- ${Yellow}NOTE: rocAL built without Audio support - Audio Functionalities will not be enabled${ColourReset}")
+    endif()
+
+    # LMDB (optional)
+    if(LMDB_FOUND)
+        target_compile_definitions(${PROJECT_NAME} PUBLIC -DROCAL_LMDB)
     endif()
 
     # LibTar

--- a/rocAL/CMakeLists.txt
+++ b/rocAL/CMakeLists.txt
@@ -350,6 +350,9 @@ if(${BUILD_ROCAL})
     # LMDB (optional)
     if(LMDB_FOUND)
         target_compile_definitions(${PROJECT_NAME} PUBLIC -DROCAL_LMDB)
+    else()
+        target_compile_definitions(${PROJECT_NAME} PUBLIC -DROCAL_LMDB=0)
+        message("-- ${Yellow}NOTE: rocAL built without LMDB - Caffe/Caffe2 LMDB readers will not be supported${ColourReset}")
     endif()
 
     # LibTar

--- a/rocAL/include/meta_data/caffe_meta_data_reader.h
+++ b/rocAL/include/meta_data/caffe_meta_data_reader.h
@@ -21,6 +21,7 @@ THE SOFTWARE.
 */
 
 #pragma once
+#ifdef ROCAL_LMDB
 #include <dirent.h>
 #include <lmdb.h>
 
@@ -63,3 +64,4 @@ class CaffeMetaDataReader : public MetaDataReader {
     MDB_txn* _mdb_txn;
     MDB_cursor* _mdb_cursor;
 };
+#endif  // ROCAL_LMDB

--- a/rocAL/include/meta_data/caffe_meta_data_reader_detection.h
+++ b/rocAL/include/meta_data/caffe_meta_data_reader_detection.h
@@ -21,6 +21,7 @@ THE SOFTWARE.
 */
 
 #pragma once
+#ifdef ROCAL_LMDB
 #include <dirent.h>
 
 #include <list>
@@ -66,3 +67,4 @@ class CaffeMetaDataReaderDetection : public MetaDataReader {
     MDB_txn* _mdb_txn;
     MDB_cursor* _mdb_cursor;
 };
+#endif  // ROCAL_LMDB

--- a/rocAL/include/readers/image/caffe2_lmdb_record_reader.h
+++ b/rocAL/include/readers/image/caffe2_lmdb_record_reader.h
@@ -21,6 +21,7 @@ THE SOFTWARE.
 */
 
 #pragma once
+#ifdef ROCAL_LMDB
 #include <dirent.h>
 #include <google/protobuf/message_lite.h>
 
@@ -97,3 +98,4 @@ class Caffe2LMDBRecordReader : public Reader {
     MDB_cursor* _read_mdb_cursor;
     void open_env_for_read_image();
 };
+#endif  // ROCAL_LMDB

--- a/rocAL/include/readers/image/caffe_lmdb_record_reader.h
+++ b/rocAL/include/readers/image/caffe_lmdb_record_reader.h
@@ -21,6 +21,7 @@ THE SOFTWARE.
 */
 
 #pragma once
+#ifdef ROCAL_LMDB
 #include <dirent.h>
 #include <google/protobuf/message_lite.h>
 #include <lmdb.h>
@@ -95,3 +96,4 @@ class CaffeLMDBRecordReader : public Reader {
     void open_env_for_read_image();
     std::shared_ptr<MetaDataReader> _meta_data_reader = nullptr;
 };
+#endif  // ROCAL_LMDB

--- a/rocAL/include/readers/image/image_reader.h
+++ b/rocAL/include/readers/image/image_reader.h
@@ -27,18 +27,22 @@ THE SOFTWARE.
 #include <vector>
 #include <random>
 
+#ifdef ROCAL_LMDB
 #include <lmdb.h>
+#endif
 #include "meta_data/meta_data_reader.h"
 #include "readers/video/video_properties.h"
 #include "pipeline/tensor.h"
 #include "pipeline/enum_registry.h"
 
+#ifdef ROCAL_LMDB
 #define CHECK_LMDB_RETURN_STATUS(status)                                                          \
     do {                                                                                          \
         if (status != MDB_SUCCESS)                                                                \
             THROW("LMDB error, " + std::string(__FILE__) + ":" + std::to_string(__LINE__) + " " + \
                   #status + ":" + std::string(mdb_strerror(status)));                             \
     } while (0)
+#endif
 
 enum class StorageType {
     FILE_SYSTEM = 0,

--- a/rocAL/source/api/rocal_api_data_loaders.cpp
+++ b/rocAL/source/api/rocal_api_data_loaders.cpp
@@ -462,6 +462,7 @@ rocalJpegCaffe2LMDBRecordSource(
     Tensor* output = nullptr;
     auto context = static_cast<Context*>(p_context);
     try {
+#ifdef ROCAL_LMDB
         bool use_input_dimension = (decode_size_policy == ROCAL_USE_USER_GIVEN_SIZE) || (decode_size_policy == ROCAL_USE_USER_GIVEN_SIZE_RESTRICTED);
         bool decoder_keep_original = (decode_size_policy == ROCAL_USE_USER_GIVEN_SIZE_RESTRICTED) || (decode_size_policy == ROCAL_USE_MAX_SIZE_RESTRICTED);
         DecoderType decType = DecoderType::TURBO_JPEG;  // default
@@ -496,6 +497,9 @@ rocalJpegCaffe2LMDBRecordSource(
             auto actual_output = context->master_graph->create_tensor(info, is_output);
             context->master_graph->add_node<CopyNode>({output}, {actual_output});
         }
+#else
+        THROW("Caffe2 LMDB reader is not enabled (rocAL built without LMDB support)")
+#endif
 
     } catch (const std::exception& e) {
         ROCAL_PRINT_EXCEPTION(context, e);
@@ -521,6 +525,7 @@ rocalJpegCaffe2LMDBRecordSourceSingleShard(
     Tensor* output = nullptr;
     auto context = static_cast<Context*>(p_context);
     try {
+#ifdef ROCAL_LMDB
         bool use_input_dimension = (decode_size_policy == ROCAL_USE_USER_GIVEN_SIZE) || (decode_size_policy == ROCAL_USE_USER_GIVEN_SIZE_RESTRICTED);
         bool decoder_keep_original = (decode_size_policy == ROCAL_USE_USER_GIVEN_SIZE_RESTRICTED) || (decode_size_policy == ROCAL_USE_MAX_SIZE_RESTRICTED);
         DecoderType decType = DecoderType::TURBO_JPEG;  // default
@@ -558,6 +563,9 @@ rocalJpegCaffe2LMDBRecordSourceSingleShard(
             auto actual_output = context->master_graph->create_tensor(info, is_output);
             context->master_graph->add_node<CopyNode>({output}, {actual_output});
         }
+#else
+        THROW("Caffe2 LMDB reader is not enabled (rocAL built without LMDB support)")
+#endif
 
     } catch (const std::exception& e) {
         ROCAL_PRINT_EXCEPTION(context, e);
@@ -582,6 +590,7 @@ rocalJpegCaffeLMDBRecordSource(
     Tensor* output = nullptr;
     auto context = static_cast<Context*>(p_context);
     try {
+#ifdef ROCAL_LMDB
         bool use_input_dimension = (decode_size_policy == ROCAL_USE_USER_GIVEN_SIZE) || (decode_size_policy == ROCAL_USE_USER_GIVEN_SIZE_RESTRICTED);
         bool decoder_keep_original = (decode_size_policy == ROCAL_USE_USER_GIVEN_SIZE_RESTRICTED) || (decode_size_policy == ROCAL_USE_MAX_SIZE_RESTRICTED);
         DecoderType decType = DecoderType::TURBO_JPEG;  // default
@@ -618,6 +627,9 @@ rocalJpegCaffeLMDBRecordSource(
             auto actual_output = context->master_graph->create_tensor(info, is_output);
             context->master_graph->add_node<CopyNode>({output}, {actual_output});
         }
+#else
+        THROW("Caffe LMDB reader is not enabled (rocAL built without LMDB support)")
+#endif
 
     } catch (const std::exception& e) {
         ROCAL_PRINT_EXCEPTION(context, e);
@@ -643,6 +655,7 @@ rocalJpegCaffeLMDBRecordSourceSingleShard(
     Tensor* output = nullptr;
     auto context = static_cast<Context*>(p_context);
     try {
+#ifdef ROCAL_LMDB
         bool use_input_dimension = (decode_size_policy == ROCAL_USE_USER_GIVEN_SIZE) || (decode_size_policy == ROCAL_USE_USER_GIVEN_SIZE_RESTRICTED);
         bool decoder_keep_original = (decode_size_policy == ROCAL_USE_USER_GIVEN_SIZE_RESTRICTED) || (decode_size_policy == ROCAL_USE_MAX_SIZE_RESTRICTED);
         DecoderType decType = DecoderType::TURBO_JPEG;  // default
@@ -680,6 +693,9 @@ rocalJpegCaffeLMDBRecordSourceSingleShard(
             auto actual_output = context->master_graph->create_tensor(info, is_output);
             context->master_graph->add_node<CopyNode>({output}, {actual_output});
         }
+#else
+        THROW("Caffe LMDB reader is not enabled (rocAL built without LMDB support)")
+#endif
 
     } catch (const std::exception& e) {
         ROCAL_PRINT_EXCEPTION(context, e);
@@ -708,6 +724,7 @@ rocalJpegCaffeLMDBRecordSourcePartialSingleShard(
     Tensor* output = nullptr;
     auto context = static_cast<Context*>(p_context);
     try {
+#ifdef ROCAL_LMDB
         bool use_input_dimension = (decode_size_policy == ROCAL_USE_USER_GIVEN_SIZE) || (decode_size_policy == ROCAL_USE_USER_GIVEN_SIZE_RESTRICTED);
 
         if (shard_count < 1)
@@ -746,6 +763,9 @@ rocalJpegCaffeLMDBRecordSourcePartialSingleShard(
             auto actual_output = context->master_graph->create_tensor(info, is_output);
             context->master_graph->add_node<CopyNode>({output}, {actual_output});
         }
+#else
+        THROW("Caffe LMDB reader is not enabled (rocAL built without LMDB support)")
+#endif
 
     } catch (const std::exception& e) {
         ROCAL_PRINT_EXCEPTION(context, e);
@@ -774,6 +794,7 @@ rocalJpegCaffe2LMDBRecordSourcePartialSingleShard(
     Tensor* output = nullptr;
     auto context = static_cast<Context*>(p_context);
     try {
+#ifdef ROCAL_LMDB
         bool use_input_dimension = (decode_size_policy == ROCAL_USE_USER_GIVEN_SIZE) || (decode_size_policy == ROCAL_USE_USER_GIVEN_SIZE_RESTRICTED);
 
         if (shard_count < 1)
@@ -811,6 +832,9 @@ rocalJpegCaffe2LMDBRecordSourcePartialSingleShard(
             auto actual_output = context->master_graph->create_tensor(info, is_output);
             context->master_graph->add_node<CopyNode>({output}, {actual_output});
         }
+#else
+        THROW("Caffe2 LMDB reader is not enabled (rocAL built without LMDB support)")
+#endif
 
     } catch (const std::exception& e) {
         ROCAL_PRINT_EXCEPTION(context, e);

--- a/rocAL/source/api/rocal_api_info.cpp
+++ b/rocAL/source/api/rocal_api_info.cpp
@@ -101,9 +101,13 @@ RocalMetaData
     rocalCreateCaffe2LMDBLabelReader(RocalContext p_context, const char *source_path, bool is_output) {
     if (!p_context)
         THROW("Invalid rocal context passed to rocalCreateCaffe2LMDBLabelReader")
-
+#ifdef ROCAL_LMDB
     auto context = static_cast<Context *>(p_context);
     return context->master_graph->create_caffe2_lmdb_record_meta_data_reader(source_path, MetaDataReaderType::CAFFE2_META_DATA_READER, MetaDataType::Label);
+#else
+    THROW("Caffe2 LMDB reader is not enabled (rocAL built without LMDB support)")
+    return nullptr;
+#endif
 }
 
 RocalMetaData
@@ -111,9 +115,13 @@ RocalMetaData
     rocalCreateCaffe2LMDBReaderDetection(RocalContext p_context, const char *source_path, bool is_output) {
     if (!p_context)
         THROW("Invalid rocal context passed to rocalCreateCaffe2LMDBReaderDetection")
+#ifdef ROCAL_LMDB
     auto context = static_cast<Context *>(p_context);
-
     return context->master_graph->create_caffe2_lmdb_record_meta_data_reader(source_path, MetaDataReaderType::CAFFE2_DETECTION_META_DATA_READER, MetaDataType::BoundingBox);
+#else
+    THROW("Caffe2 LMDB reader is not enabled (rocAL built without LMDB support)")
+    return nullptr;
+#endif
 }
 
 RocalMetaData
@@ -121,8 +129,13 @@ RocalMetaData
     rocalCreateCaffeLMDBLabelReader(RocalContext p_context, const char *source_path) {
     if (!p_context)
         THROW("Invalid rocal context passed to rocalCreateCaffeLMDBLabelReader")
+#ifdef ROCAL_LMDB
     auto context = static_cast<Context *>(p_context);
     return context->master_graph->create_caffe_lmdb_record_meta_data_reader(source_path, MetaDataReaderType::CAFFE_META_DATA_READER, MetaDataType::Label);
+#else
+    THROW("Caffe LMDB reader is not enabled (rocAL built without LMDB support)")
+    return nullptr;
+#endif
 }
 
 RocalMetaData
@@ -130,9 +143,13 @@ RocalMetaData
     rocalCreateCaffeLMDBReaderDetection(RocalContext p_context, const char *source_path) {
     if (!p_context)
         THROW("Invalid rocal context passed to rocalCreateCaffeLMDBReaderDetection")
+#ifdef ROCAL_LMDB
     auto context = static_cast<Context *>(p_context);
-
     return context->master_graph->create_caffe_lmdb_record_meta_data_reader(source_path, MetaDataReaderType::CAFFE_DETECTION_META_DATA_READER, MetaDataType::BoundingBox);
+#else
+    THROW("Caffe LMDB reader is not enabled (rocAL built without LMDB support)")
+    return nullptr;
+#endif
 }
 
 size_t ROCAL_API_CALL rocalIsEmpty(RocalContext p_context) {

--- a/rocAL/source/meta_data/caffe2_meta_data_reader.cpp
+++ b/rocAL/source/meta_data/caffe2_meta_data_reader.cpp
@@ -20,6 +20,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
+#ifdef ROCAL_LMDB
 #include "meta_data/caffe2_meta_data_reader.h"
 
 #include <google/protobuf/message_lite.h>
@@ -168,3 +169,4 @@ void Caffe2MetaDataReader::release() {
 
 Caffe2MetaDataReader::Caffe2MetaDataReader() {
 }
+#endif  // ROCAL_LMDB

--- a/rocAL/source/meta_data/caffe2_meta_data_reader_detection.cpp
+++ b/rocAL/source/meta_data/caffe2_meta_data_reader_detection.cpp
@@ -20,6 +20,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
+#ifdef ROCAL_LMDB
 #include "meta_data/caffe2_meta_data_reader_detection.h"
 
 #include <google/protobuf/message_lite.h>
@@ -208,3 +209,4 @@ void Caffe2MetaDataReaderDetection::release() {
 
 Caffe2MetaDataReaderDetection::Caffe2MetaDataReaderDetection() {
 }
+#endif  // ROCAL_LMDB

--- a/rocAL/source/meta_data/caffe_meta_data_reader.cpp
+++ b/rocAL/source/meta_data/caffe_meta_data_reader.cpp
@@ -20,6 +20,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
+#ifdef ROCAL_LMDB
 #include "meta_data/caffe_meta_data_reader.h"
 
 #include <string.h>
@@ -136,3 +137,4 @@ void CaffeMetaDataReader::read_lmdb_record(std::string _path, uint file_byte_siz
     mdb_txn_abort(_mdb_txn);
     mdb_env_close(_mdb_env);
 }
+#endif  // ROCAL_LMDB

--- a/rocAL/source/meta_data/caffe_meta_data_reader_detection.cpp
+++ b/rocAL/source/meta_data/caffe_meta_data_reader_detection.cpp
@@ -20,6 +20,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
+#ifdef ROCAL_LMDB
 #include <iostream>
 #include <fstream>
 #include <utility>
@@ -186,3 +187,4 @@ void CaffeMetaDataReaderDetection::release() {
 
 CaffeMetaDataReaderDetection::CaffeMetaDataReaderDetection() {
 }
+#endif  // ROCAL_LMDB

--- a/rocAL/source/meta_data/meta_data_reader_factory.cpp
+++ b/rocAL/source/meta_data/meta_data_reader_factory.cpp
@@ -24,10 +24,12 @@ THE SOFTWARE.
 
 #include <memory>
 
+#ifdef ROCAL_LMDB
 #include "meta_data/caffe2_meta_data_reader.h"
 #include "meta_data/caffe2_meta_data_reader_detection.h"
 #include "meta_data/caffe_meta_data_reader.h"
 #include "meta_data/caffe_meta_data_reader_detection.h"
+#endif
 #include "meta_data/cifar10_meta_data_reader.h"
 #include "meta_data/coco_meta_data_reader.h"
 #include "meta_data/coco_meta_data_reader_key_points.h"
@@ -111,6 +113,7 @@ std::shared_ptr<MetaDataReader> create_meta_data_reader(const MetaDataConfig& co
             meta_data_reader->init(config, meta_data_batch);
             return meta_data_reader;
         } break;
+#ifdef ROCAL_LMDB
         case MetaDataReaderType::CAFFE_META_DATA_READER: {
             if (config.type() != MetaDataType::Label)
                 THROW("CAFFE_META_DATA_READER can only be used to load labels")
@@ -143,6 +146,13 @@ std::shared_ptr<MetaDataReader> create_meta_data_reader(const MetaDataConfig& co
             meta_data_reader->init(config, meta_data_batch);
             return meta_data_reader;
         } break;
+#else
+        case MetaDataReaderType::CAFFE_META_DATA_READER:
+        case MetaDataReaderType::CAFFE_DETECTION_META_DATA_READER:
+        case MetaDataReaderType::CAFFE2_META_DATA_READER:
+        case MetaDataReaderType::CAFFE2_DETECTION_META_DATA_READER:
+            THROW("LMDB meta data reader is not enabled (rocAL built without LMDB support)")
+#endif
         case MetaDataReaderType::MXNET_META_DATA_READER: {
             if (config.type() != MetaDataType::Label)
                 THROW("MXNetMetaDataReader can only be used to load labels")

--- a/rocAL/source/readers/image/caffe2_lmdb_record_reader.cpp
+++ b/rocAL/source/readers/image/caffe2_lmdb_record_reader.cpp
@@ -20,6 +20,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
+#ifdef ROCAL_LMDB
 #include "readers/image/caffe2_lmdb_record_reader.h"
 #include <iostream>
 #include <sstream>
@@ -266,3 +267,4 @@ void Caffe2LMDBRecordReader::read_image(unsigned char *buff, std::string file_na
     mdb_cursor_close(_read_mdb_cursor);
     _read_mdb_cursor = nullptr;
 }
+#endif  // ROCAL_LMDB

--- a/rocAL/source/readers/image/caffe_lmdb_record_reader.cpp
+++ b/rocAL/source/readers/image/caffe_lmdb_record_reader.cpp
@@ -20,6 +20,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
+#ifdef ROCAL_LMDB
 #include "readers/image/caffe_lmdb_record_reader.h"
 
 #include "pipeline/commons.h"
@@ -260,3 +261,4 @@ void CaffeLMDBRecordReader::read_image(unsigned char *buff, std::string file_nam
     mdb_cursor_close(_read_mdb_cursor);
     _read_mdb_cursor = nullptr;
 }
+#endif  // ROCAL_LMDB

--- a/rocAL/source/readers/image/reader_factory.cpp
+++ b/rocAL/source/readers/image/reader_factory.cpp
@@ -26,8 +26,10 @@ THE SOFTWARE.
 #include <stdexcept>
 
 #include "readers/file_source_reader.h"
+#ifdef ROCAL_LMDB
 #include "readers/image/caffe2_lmdb_record_reader.h"
 #include "readers/image/caffe_lmdb_record_reader.h"
+#endif
 #include "readers/image/cifar10_data_reader.h"
 #include "readers/image/coco_file_source_reader.h"
 #include "readers/image/external_source_reader.h"
@@ -69,6 +71,7 @@ std::shared_ptr<Reader> create_reader(ReaderConfig config) {
                 throw std::runtime_error("CFar10 data reader cannot access the storage");
             return ret;
         } break;
+#ifdef ROCAL_LMDB
         case StorageType::CAFFE_LMDB_RECORD: {
             auto ret = std::make_shared<CaffeLMDBRecordReader>();
             if (ret->initialize(config) != Reader::Status::OK)
@@ -81,6 +84,11 @@ std::shared_ptr<Reader> create_reader(ReaderConfig config) {
                 throw std::runtime_error("Caffe2LMDBRecordReader cannot access the storage");
             return ret;
         } break;
+#else
+        case StorageType::CAFFE_LMDB_RECORD:
+        case StorageType::CAFFE2_LMDB_RECORD:
+            throw std::runtime_error("LMDB reader is not enabled (rocAL built without LMDB support)");
+#endif
         case StorageType::MXNET_RECORDIO: {
             auto ret = std::make_shared<MXNetRecordIOReader>();
             if (ret->initialize(config) != Reader::Status::OK)

--- a/rocAL_pybind/amd/rocal/decoders.py
+++ b/rocAL_pybind/amd/rocal/decoders.py
@@ -95,6 +95,8 @@ def image(*inputs, user_feature_key_map=None, path='', file_root='', annotations
             Pipeline._current_pipeline._handle, *(kwargs_pybind.values()))
 
     elif (reader == "Caffe2Reader" or reader == "Caffe2ReaderDetection"):
+        if not hasattr(b, 'caffe2ImageDecoderShard'):
+            raise RuntimeError("rocAL was built without LMDB support. Caffe2 LMDB decoders are not available.")
         kwargs_pybind = {
             "source_path": path,
             "color_format": output_type,
@@ -112,6 +114,8 @@ def image(*inputs, user_feature_key_map=None, path='', file_root='', annotations
             Pipeline._current_pipeline._handle, *(kwargs_pybind.values()))
 
     elif reader == "CaffeReader" or reader == "CaffeReaderDetection":
+        if not hasattr(b, 'caffeImageDecoderShard'):
+            raise RuntimeError("rocAL was built without LMDB support. Caffe LMDB decoders are not available.")
         kwargs_pybind = {
             "source_path": path,
             "color_format": output_type,
@@ -285,6 +289,8 @@ def image_random_crop(*inputs, user_feature_key_map=None, path='', file_root='',
         crop_output_image = b.tfImageDecoder(
             Pipeline._current_pipeline._handle, *(kwargs_pybind.values()))
     elif (reader == "CaffeReader" or reader == "CaffeReaderDetection"):
+        if not hasattr(b, 'caffeImageDecoderPartialShard'):
+            raise RuntimeError("rocAL was built without LMDB support. Caffe LMDB decoders are not available.")
         kwargs_pybind = {
             "source_path": path,
             "color_format": output_type,
@@ -303,6 +309,8 @@ def image_random_crop(*inputs, user_feature_key_map=None, path='', file_root='',
         crop_output_image = b.caffeImageDecoderPartialShard(
             Pipeline._current_pipeline._handle, *(kwargs_pybind.values()))
     elif (reader == "Caffe2Reader" or reader == "Caffe2ReaderDetection"):
+        if not hasattr(b, 'caffe2ImageDecoderShard'):
+            raise RuntimeError("rocAL was built without LMDB support. Caffe2 LMDB decoders are not available.")
         kwargs_pybind = {
             "source_path": path,
             "color_format": output_type,
@@ -398,6 +406,8 @@ def image_slice(*inputs, file_root='', path='', annotations_file='', shard_id=0,
         image_decoder_slice = b.cocoImageDecoderSliceShard(
             Pipeline._current_pipeline._handle, *(kwargs_pybind.values()))
     elif (reader == "CaffeReader" or reader == "CaffeReaderDetection"):
+        if not hasattr(b, 'caffeImageDecoderPartialShard'):
+            raise RuntimeError("rocAL was built without LMDB support. Caffe LMDB decoders are not available.")
         kwargs_pybind = {
             "source_path": path,
             "color_format": output_type,
@@ -417,6 +427,8 @@ def image_slice(*inputs, file_root='', path='', annotations_file='', shard_id=0,
         image_decoder_slice = b.caffeImageDecoderPartialShard(
             Pipeline._current_pipeline._handle, *(kwargs_pybind.values()))
     elif (reader == "Caffe2Reader" or reader == "Caffe2ReaderDetection"):
+        if not hasattr(b, 'caffe2ImageDecoderShard'):
+            raise RuntimeError("rocAL was built without LMDB support. Caffe2 LMDB decoders are not available.")
         kwargs_pybind = {
             "source_path": path,
             "color_format": output_type,

--- a/rocAL_pybind/amd/rocal/readers.py
+++ b/rocAL_pybind/amd/rocal/readers.py
@@ -138,6 +138,8 @@ def caffe(path, bbox=False, stick_to_shard=False, pad_last_batch=False):
 
         @return    caffe reader meta data, bboxes, and labels.
     """
+    if not hasattr(b, 'caffeReader'):
+        raise RuntimeError("rocAL was built without LMDB support. Caffe LMDB readers are not available.")
     # Output
     bboxes = []
     labels = []
@@ -168,6 +170,8 @@ def caffe2(path, bbox=False, stick_to_shard=False, pad_last_batch=False):
 
         @return    caffe2 reader meta data, bboxes, and labels.
     """
+    if not hasattr(b, 'caffe2Reader'):
+        raise RuntimeError("rocAL was built without LMDB support. Caffe2 LMDB readers are not available.")
     # Output
     bboxes = []
     labels = []

--- a/rocAL_pybind/rocal_pybind.cpp
+++ b/rocAL_pybind/rocal_pybind.cpp
@@ -886,10 +886,12 @@ py::class_<rocalListOfTensorList>(m, "rocalListOfTensorList")
     m.def("setOutputs", &rocalSetOutputs);
     m.def("tfReader", &rocalCreateTFReader, py::return_value_policy::reference);
     m.def("tfReaderDetection", &rocalCreateTFReaderDetection, py::return_value_policy::reference);
+#ifdef ROCAL_LMDB
     m.def("caffeReader", &rocalCreateCaffeLMDBLabelReader, py::return_value_policy::reference);
     m.def("caffe2Reader", &rocalCreateCaffe2LMDBLabelReader, py::return_value_policy::reference);
     m.def("caffeReaderDetection", &rocalCreateCaffeLMDBReaderDetection, py::return_value_policy::reference);
     m.def("caffe2ReaderDetection", &rocalCreateCaffe2LMDBReaderDetection, py::return_value_policy::reference);
+#endif
     m.def("mxnetReader", &rocalCreateMXNetReader, py::return_value_policy::reference);
     m.def("webDatasetReader", &rocalCreateWebDatasetReader, py::return_value_policy::reference);
     m.def("isEmpty", &rocalIsEmpty);
@@ -1108,6 +1110,7 @@ py::class_<rocalListOfTensorList>(m, "rocalListOfTensorList")
           py::return_value_policy::reference);
     m.def("tfImageDecoder", &rocalJpegTFRecordSource, "Reads file from the source given and decodes it according to the policy only for TFRecords",
           py::return_value_policy::reference);
+#ifdef ROCAL_LMDB
     m.def("caffeImageDecoder", &rocalJpegCaffeLMDBRecordSource, "Reads file from the source given and decodes it according to the policy",
           py::return_value_policy::reference);
     m.def("caffeImageDecoderShard", &rocalJpegCaffeLMDBRecordSourceSingleShard, "Reads file from the source given and decodes it according to the shard id and number of shards",
@@ -1120,6 +1123,7 @@ py::class_<rocalListOfTensorList>(m, "rocalListOfTensorList")
           py::return_value_policy::reference);
     m.def("caffe2ImageDecoderPartialShard", &rocalJpegCaffe2LMDBRecordSourcePartialSingleShard, "Reads file from the source given and partially decodes it according to the shard id and number of shards",
           py::return_value_policy::reference);
+#endif
     m.def("fusedDecoderCrop", &rocalFusedJpegCrop, "Reads file from the source and decodes them partially to output random crops",
           py::return_value_policy::reference);
     m.def("fusedDecoderCropShard", &rocalFusedJpegCropSingleShard, "Reads file from the source and decodes them partially to output random crops",


### PR DESCRIPTION
## Motivation

On some OS configurations, LMDB may not be available, causing the rocAL build to fail even though LMDB is only needed for Caffe/Caffe2 LMDB readers. This change makes LMDB an optional dependency. When LMDB is not present, the build succeeds and LMDB reader APIs return clear error messages at runtime.

## Technical Details

- C++ headers/sources: wrap Caffe/Caffe2 LMDB readers and metadata readers with #ifdef ROCAL_LMDB
- API layer: LMDB data loader and metadata functions throw descriptive errors when called without LMDB support
- Pybind: conditionally expose LMDB bindings; Python layer checks availability with hasattr() before calling
- Packaging: remove liblmdb-dev/lmdb-devel from required package lists
- Setup script: comment out LMDB packages
- ReadMe: LMDB marked as an optional dependency

## Test Plan

Three-phase validation:                                                              
                                                                                                                                 
  1. **Baseline** (clean `develop`, LMDB present)                                               
  2. **Feature branch + LMDB** - verify zero regressions vs baseline                                                             
  3. **Feature branch - LMDB** -  verify graceful degradation                                                                     
                                                                                                                                 
  Each phase verifies:                                                                                                           
  - CMake configure + build                                                                                                      
  - C++ ctests (21 tests)                                                                                                        
  - PyBind ctests (6 tests)                                                                                                      
  - Python API tests (15 tests: unit_test, coco_reader, decoder, tf_classification, tf_detection, video_pipeline, numpy_reader,  
  web_dataset_reader, external_source, pipeline, pipeline_serialize, caffe_reader x2, caffe2_reader x2)

## Test Result

| Test Layer             | Phase 1 (baseline) | Phase 2 (branch + LMDB) | Phase 3 (branch - LMDB)    |
  |------------------------|--------------------|--------------------------|-----------------------------|                       
  | Build                  | PASS               | PASS, ROCAL_LMDB defined | PASS, no LMDB linked        |                       
  | C++ ctests (21)        | 21/21 PASS         | 21/21 PASS               | 21/21 PASS                  |                       
  | PyBind ctests (6)      | 6/6 PASS           | 6/6 PASS                 | 6/6 PASS                    |                       
  | Python non-LMDB (11)   | 11/11 PASS         | 11/11 PASS               | 11/11 PASS                  |                       
  | Python LMDB (4)        | 4/4 PASS           | 4/4 PASS                 | Clean RuntimeError (expected)|                      
                                                                                                                                 
Without LMDB, Caffe/Caffe2 reader tests produce clear RuntimeError: rocAL was built without LMDB support. No segfaults or undefined symbols.