### PR TITLE
Fix race condition in MasterGraph destruction/rocalRelease()

### DIFF
--- a/rocAL/source/pipeline/master_graph.cpp
+++ b/rocAL/source/pipeline/master_graph.cpp
@@ -388,6 +388,8 @@ void MasterGraph::release() {
     _meta_data_nodes.clear();
     _tensor_map.clear();
     _ring_buffer.release_gpu_res();
+    // pipelines' associated vx nodes must have vxReleaseNode called before vxReleaseContext to avoid race condition
+    _pipeline_operators.clear();
     // shut_down loader:: required for releasing any allocated resourses
     for (auto &loader_module : _loader_modules)
         loader_module->shut_down();


### PR DESCRIPTION
## Motivation

Fixes #484 .

## Technical Details
Added `_pipeline_operators.clear()` in `MasterGraph::release()` (called from the MasterGraph destructor) before `vxReleaseContext()`.
This ensures the pipeline's associated VX nodes are released safely before their context is destroyed. Otherwise, there is a race between `vxReleaseContext()` in `MasterGraph::release()`, which deletes a critical section, and the pipeline members' destructors that are called after the MasterGraph destructor, which try to acquire that lock. 

## Test Plan

Used debug statements to verify new ordering, and ran ctests repeatedly to verify consistent success.

## Test Result

The ctests now consistently all pass.
Debug statements show the proper ordering (solving the issue described in #484):
```
rocAL reset
DESTRUCTOR: PipelineOperator::~PipelineOperator() for ImageLoaderNode_0
DESTRUCTOR: PipelineOperator::~PipelineOperator() for LabelReader_1
DESTRUCTOR: PipelineOperator::~PipelineOperator() for _2
vxReleaseNode entry
agoReleaseNode entry, about to try acquiring lock
agoReleaseNode exit
vxReleaseNode exit
vxReleaseContext entry
AgoGraph::~AgoGraph - destroyed critical section at 0x56c49033dae0
vxReleaseContext exit
MasterGraph::~MasterGraph exit
```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
