### PR TITLE
[CMakeLists.txt] update gfx115x(gfx1150,gfx1152 & gfx1153) GPU architecture support

### DIFF
--- a/rocAL/CMakeLists.txt
+++ b/rocAL/CMakeLists.txt
@@ -100,7 +100,7 @@ if(GPU_SUPPORT AND "${BACKEND}" STREQUAL "HIP")
         else() # if we don't have rocm_check_target_ids, just assume the targets are available
             set(OPTIONAL_GPU_TARGETS_AVAILABLE "${OPTIONAL_GPU_TARGETS}")
         endif()
-        set(DEFAULT_GPU_TARGETS "gfx908;gfx90a;gfx942;gfx1030;gfx1031;gfx1032;gfx1100;gfx1101;gfx1102;gfx1151;gfx950;gfx1200;gfx1201;${OPTIONAL_GPU_TARGETS_AVAILABLE}")
+        set(DEFAULT_GPU_TARGETS "gfx908;gfx90a;gfx942;gfx1030;gfx1031;gfx1032;gfx1100;gfx1101;gfx1102;gfx1150;gfx1151;gfx1152;gfx1153;gfx950;gfx1200;gfx1201;${OPTIONAL_GPU_TARGETS_AVAILABLE}")
     endif()
 
     # Set AMD GPU_TARGETS


### PR DESCRIPTION
## Motivation

[rocAL] Enable AMD Strix Point(gfx1150), Krackan Point(gfx1152) and Krackan2(gfx1153) architecture support.

## Technical Details

Add gfx1150, gfx1152 and gfx1153 to the DEFAULT_GPU_TARGETS list in CMakeLists.txt to enable rocAL library builds for these AMD RDNA3.5 GPU architectures.

Changes:
CMakeLists.txt: Added gfx1150 to DEFAULT_GPU_TARGETS between gfx1102 and gfx1151
CMakeLists.txt: Added gfx1152 and gfx1153 entries to
DEFAULT_AMDGPU_TARGETS between gfx1151 and gfx950
Background:
The gfx1150, gfx1152 and gfx1153 are part of the RDNA3.5 GPU family.
Adding these targets ensures that rocAL can be compiled
with native support for these GPUs without requiring users to
manually specify GPU_TARGETS.

Since gfx115x represents the same IP level, include all known variants
to ensure consistent support across the family.

## Test Plan

All ctests must pass

## Test Result

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
