### PR TITLE
Workflow to test rocAL on HIP

### DIFF
--- a/.github/workflows/conformance-hip.yml
+++ b/.github/workflows/conformance-hip.yml
@@ -108,4 +108,5 @@ jobs:
           make install
       - name: Run tests
         run: |
+          cd build
           make test

--- a/.github/workflows/conformance-hip.yml
+++ b/.github/workflows/conformance-hip.yml
@@ -79,13 +79,16 @@ jobs:
           amd-smi || true
       - name: Install RPP
         run: |
-          git clone --depth 1 https://github.com/ROCm/rpp.git
-          cd rpp
-          mkdir build && cd build
+          git clone --depth 1 --filter=blob:none --sparse https://github.com/ROCm/rocm-libraries.git
+          cd rocm-libraries
+          git sparse-checkout set projects/rpp
+          cd projects/rpp
+          mkdir build
+          cd build
           cmake ..
           make -j$(nproc)
           make install
-          cd ../..
+          cd ../../../../
       - name: Install MIVisionX (HIP)
         run: |
           git clone --depth 1 https://github.com/ROCm/MIVisionX.git
@@ -109,4 +112,5 @@ jobs:
       - name: Run tests
         run: |
           cd build
-          make test
+          ctest -VV
+          ctest -VV --rerun-failed

--- a/.github/workflows/conformance-hip.yml
+++ b/.github/workflows/conformance-hip.yml
@@ -113,5 +113,4 @@ jobs:
       - name: Run tests
         run: |
           cd build
-          ctest -VV
-          ctest -VV --rerun-failed
+          ctest -VV || ctest -VV --rerun-failed

--- a/.github/workflows/conformance-hip.yml
+++ b/.github/workflows/conformance-hip.yml
@@ -1,0 +1,111 @@
+# Copyright (c) 2015 - 2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+name: rocAL CI (HIP)
+
+on:
+  push:
+    branches: [master, main, develop]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+  pull_request:
+    branches: [master, main, develop]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  ROCM_PATH: /opt/rocm
+  LD_LIBRARY_PATH: /opt/rocm/lib
+
+# Cancel superseded runs of the same ref so rapid pushes to a PR don't queue up
+# many full GPU pipelines and starve the runners. Pushes to default branches keep
+# a stable group per ref.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-test:
+    name: Build rocAL (HIP)
+    runs-on:
+      group: linux-shark42-runner-group
+    container:
+      image: mivisionx/ubuntu-24.04:rocm-20260710
+      options: --device /dev/kfd --device /dev/dri
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      - name: Install dependencies
+        run: |
+          apt-get update -qq
+          apt-get install -y --no-install-recommends build-essential cmake git python3 \
+          libprotobuf-dev libprotoc-dev protobuf-compiler libturbojpeg0-dev liblmdb-dev libjpeg-dev \
+          pkg-config ffmpeg libavcodec-dev libavformat-dev libavutil-dev libswscale-dev
+          git clone --depth 1 https://github.com/Tencent/rapidjson.git
+          cd rapidjson
+          mkdir build
+          cd build
+          cmake ../ -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DRAPIDJSON_BUILD_EXAMPLES=OFF -DRAPIDJSON_BUILD_TESTS=OFF -DRAPIDJSON_BUILD_DOC=OFF
+          make -j$(nproc)
+          make install
+          cd ../..
+      - name: Validate ROCm
+        run: |
+          rocminfo
+          amd-smi || true
+      - name: Install RPP
+        run: |
+          git clone --depth 1 https://github.com/ROCm/rpp.git
+          cd rpp
+          mkdir build && cd build
+          cmake ..
+          make -j$(nproc)
+          make install
+          cd ../..
+      - name: Install MIVisionX (HIP)
+        run: |
+          git clone --depth 1 https://github.com/ROCm/MIVisionX.git
+          cd MIVisionX
+          mkdir build && cd build
+          cmake .. \
+            -DBACKEND=HIP \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_C_COMPILER="${ROCM_PATH}/bin/amdclang" \
+            -DCMAKE_CXX_COMPILER="${ROCM_PATH}/bin/amdclang++"
+          make -j$(nproc)
+          make install
+          cd ../..
+      - name: Install rocAL
+        run: |
+          mkdir build
+          cd build
+          cmake .. DBUILD_PYPACKAGE=OFF -DCMAKE_DISABLE_FIND_PACKAGE_rocdecode=ON
+          make -j$(nproc)
+          make install
+      - name: Run tests
+        run: |
+          make test

--- a/.github/workflows/conformance-hip.yml
+++ b/.github/workflows/conformance-hip.yml
@@ -39,6 +39,7 @@ defaults:
 env:
   ROCM_PATH: /opt/rocm
   LD_LIBRARY_PATH: /opt/rocm/lib
+  HIP_VISIBLE_DEVICES: 0
 
 # Cancel superseded runs of the same ref so rapid pushes to a PR don't queue up
 # many full GPU pipelines and starve the runners. Pushes to default branches keep

--- a/.github/workflows/conformance-hip.yml
+++ b/.github/workflows/conformance-hip.yml
@@ -103,7 +103,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake .. DBUILD_PYPACKAGE=OFF -DCMAKE_DISABLE_FIND_PACKAGE_rocdecode=ON
+          cmake .. -DBUILD_PYPACKAGE=OFF -DCMAKE_DISABLE_FIND_PACKAGE_rocdecode=ON
           make -j$(nproc)
           make install
       - name: Run tests


### PR DESCRIPTION
This workflow installs RPP, MIVisionX, and rocAL and runs all ctests on rocAL except the rocDecode ones.

Tested locally up until now so it might fail. 