### PR TITLE
conformance-hip.yml: Add symlink to Mesa driver during set up

### DIFF
--- a/.github/workflows/conformance-hip.yml
+++ b/.github/workflows/conformance-hip.yml
@@ -66,6 +66,8 @@ jobs:
           apt-get install -y --no-install-recommends build-essential cmake git python3 \
           libprotobuf-dev libprotoc-dev protobuf-compiler libturbojpeg0-dev liblmdb-dev libjpeg-dev \
           pkg-config ffmpeg libavcodec-dev libavformat-dev libavutil-dev libswscale-dev
+          ln -s /usr/lib/x86_64-linux-gnu/libgallium-25.2.8-0ubuntu0.24.04.2.so \
+          /usr/lib/x86_64-linux-gnu/dri/radeonsi_drv_video.so
           git clone --depth 1 https://github.com/Tencent/rapidjson.git
           cd rapidjson
           mkdir build

--- a/.github/workflows/conformance-hip.yml
+++ b/.github/workflows/conformance-hip.yml
@@ -66,7 +66,7 @@ jobs:
           apt-get install -y --no-install-recommends build-essential cmake git python3 \
           libprotobuf-dev libprotoc-dev protobuf-compiler libturbojpeg0-dev liblmdb-dev libjpeg-dev \
           pkg-config ffmpeg libavcodec-dev libavformat-dev libavutil-dev libswscale-dev
-          ln -s /usr/lib/x86_64-linux-gnu/libgallium-25.2.8-0ubuntu0.24.04.2.so \
+          ln -s /usr/lib/x86_64-linux-gnu/libgallium-*.so \
           /usr/lib/x86_64-linux-gnu/dri/radeonsi_drv_video.so
           git clone --depth 1 https://github.com/Tencent/rapidjson.git
           cd rapidjson


### PR DESCRIPTION
## Motivation

PR #482 fails the CI rocJPEG ctests (`basic_test_rocjpeg_rgb` and `basic_test_rocjpeg_gray`) because VA-API is unable to find the mesa driver at `/usr/lib/x86_64-linux-gnu/dri/radeonsi_drv_video.so`.

## Technical Details
Creates a symlink so that `/usr/lib/x86_64-linux-gnu/dri/radeonsi_drv_video.so` points to the driver at `/usr/lib/x86_64-linux-gnu/libgallium-*.so`.

Original ctest error message: 
```
16: InitVAAPI(drm_node) returned ROCJPEG_STATUS_NOT_INITIALIZED at                                                                                     
  /__w/rockrel/rockrel/rocm-systems/projects/rocjpeg/src/rocjpeg_vaapi_decoder.cpp:420                                                                   
16: [0, Critical] rocjpeg_decoder.cpp:93: 159627647708 us: [pid:59008 tid:59008 hashid:0x52ada] InitializeDecoder(): Failed to initialize the VA-API   
  JPEG decoder!                                                                                                                                          
16: rocJpegCreate(rocjpeg_backend, device_id, &_rocjpeg_handle) returned ROCJPEG_STATUS_NOT_INITIALIZED at                                             
  /rocAL/rocAL/source/decoders/image/rocjpeg_decoder.cpp:68 
```
Creating the symlink eliminates this error.

## Test Result
The rocJPEG ctests now pass when this is run on my own system.