### PR TITLE
[Chore]: Use rocDecode test pkg instead of full source install

### DIFF
--- a/.github/workflows/conformance-hip.yml
+++ b/.github/workflows/conformance-hip.yml
@@ -67,7 +67,8 @@ jobs:
           apt-get update -qq
           apt-get install -y --no-install-recommends build-essential cmake git python3 \
           libprotobuf-dev libprotoc-dev protobuf-compiler libturbojpeg0-dev liblmdb-dev libjpeg-dev \
-          pkg-config ffmpeg libavcodec-dev libavformat-dev libavutil-dev libswscale-dev
+          pkg-config ffmpeg libavcodec-dev libavformat-dev libavutil-dev libswscale-dev \
+          amdrocm-decode-test
           git clone --depth 1 https://github.com/Tencent/rapidjson.git
           cd rapidjson
           mkdir build
@@ -80,18 +81,6 @@ jobs:
         run: |
           rocminfo
           amd-smi || true
-      - name: Install rocDecode
-        run: |
-          git clone --depth 1 --filter=blob:none --sparse https://github.com/ROCm/rocm-systems.git
-          cd rocm-systems
-          git sparse-checkout set projects/rocdecode
-          cd projects/rocdecode
-          mkdir build
-          cd build
-          cmake ..
-          make -j$(nproc)
-          make install
-          cd ../../../../
       - name: Install RPP
         run: |
           git clone --depth 1 --filter=blob:none --sparse https://github.com/ROCm/rocm-libraries.git

--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ rocAL can be currently used to perform the following operations either with rand
 ### Libraries
 See [installation instructions](#installation-instructions) for more details and instructions on the prerequisite libraries.
 
-* CMake (Version `3.10` or later)
 * MIVisionX (note different installation instructions for package and source)
+* CMake (Version `3.10` or later)
 * Google Protobuf (Version `3.12.4` or later)
 * TurboJPEG (Version `2.0` or later)
 * Python3 and Python3 PIP
@@ -93,6 +93,9 @@ See [installation instructions](#installation-instructions) for more details and
 * pkg-config
 * PyBind11
 * RapidJSON
+
+Additional required libraries for  source install only:
+* rocDecode test package
 
 Additional required libraries for package install only (for source install, these are provided by ROCm `7.13` or later):
 * HIP
@@ -241,6 +244,10 @@ Available for **ROCm `7.2.x` and below**.
 For **ROCm `7.13` and above**.
 
 Install the additional source prerequisites:
+* rocDecode test package
+  ```shell
+  sudo apt install amdrocm-decode-test
+  ```
 * [MIVisionX](https://github.com/ROCm/MIVisionX) - Manual install
   * Source: `https://github.com/ROCm/MIVisionX`
 

--- a/docs/install/rocAL-prerequisites.rst
+++ b/docs/install/rocAL-prerequisites.rst
@@ -71,7 +71,30 @@ Use the following commands to install those packages (make sure to also manually
       sudo zypper install python3-devel python3-pip python3-wheel
       sudo zypper install lmdb-devel # optional: needed for Caffe/Caffe2 LMDB reader support
 
-For **source install**, it is also required to install MIVisionX manually (`<https://github.com/ROCm/MIVisionX>`_).
+For **source install**, it is also required to install the following prerequisites:
+
+* MIVisionX manually (`<https://github.com/ROCm/MIVisionX>`_).
+* rocDecode test package:
+
+  .. tab-set::
+
+    .. tab-item:: Ubuntu
+
+      .. code:: shell
+
+        sudo apt install amdrocm-decode-test
+
+    .. tab-item:: RHEL
+
+      .. code:: shell
+
+        sudo dnf install amdrocm-decode-test
+
+    .. tab-item:: SLES
+
+      .. code:: shell
+
+        sudo zypper install amdrocm-decode-test
 
 For **package install**, it is also required to install the following prerequisites:
 


### PR DESCRIPTION
## Motivation
Fixes #495: The CI now gets the required utils/ files for rocDecode by installing the `amdrocm-decode-test` package, rather than doing a source install. The README and docs are also updated to reflect this method. 

## Test Plan
Tested the updated CI by running its commands on the same Docker image locally. Also ran the sphinx docs html on local port to verify that it looked right.

## Test Result
Successfully installed the `utils/` directory, built, and passed CTests.