### PR TITLE
[BugFix]: dataloader_multithread test to propagate shard thread failures as non-zero exit code

### DIFF
--- a/tests/cpp_api/dataloader_multithread/dataloader_multithread.cpp
+++ b/tests/cpp_api/dataloader_multithread/dataloader_multithread.cpp
@@ -27,6 +27,7 @@ THE SOFTWARE.
 #include <cstdlib>
 #include <cstdio>
 #include <cstring>
+#include <future>
 #include <iostream>
 #include <mutex>
 #include <string>
@@ -265,15 +266,21 @@ int main(int argc, const char **argv) {
     std::cout << "Number of GPUs: " << num_gpus << std::endl;
 
     // launch threads process shards
-    std::vector<std::thread> loader_threads(num_shards);
+    std::vector<std::future<int>> loader_threads(num_shards);
     auto gpu_id = num_gpus ? 0 : -1;
     int th_id;
     for (th_id = 0; th_id < num_shards; th_id++) {
-        loader_threads[th_id] = std::thread(thread_func, path, gpu_id, RocalImageColor::ROCAL_COLOR_RGB24, th_id, num_shards, decode_width, decode_height, inputBatchSize,
+        loader_threads[th_id] = std::async(std::launch::async, thread_func, path, gpu_id, RocalImageColor::ROCAL_COLOR_RGB24, th_id, num_shards, decode_width, decode_height, inputBatchSize,
                                             shuffle, display, dec_mode, cpu_thread_count);
         if (num_gpus) gpu_id = (gpu_id + 1) % num_gpus;
     }
-    for (auto &th : loader_threads) {
-        th.join();
+    int ret_status = 0;
+    for (th_id = 0; th_id < num_shards; th_id++) {
+        int shard_status = loader_threads[th_id].get();
+        if (shard_status != 0) {
+            std::cout << "shard_id: " << th_id << " failed with status " << shard_status << std::endl;
+            ret_status = -1;
+        }
     }
+    return ret_status;
 }


### PR DESCRIPTION
## Motivation
Fixes #499: Dataloader tests don't check return value, can return false positive

## Technical Details
- Replaced `std::vector<std::thread>` with `std::vector<std::future<int>>`, launching each shard via `std::async(std::launch::async, thread_func, ...)` instead of `std::thread`.
- After launching all shards, the results are collected via `future::get()`, which blocks until each shard completes and returns its actual status.
- If any shard returns non-zero, its shard id and status are printed, and `main()` now returns a non-zero exit code instead of always returning `0`.

## Test Plan
Built rocAL with the HIP backend, then manually forced a shard failure by requesting more GPU ids than physically exist (`num_shards=3 num_gpus=3` on a machine with 2 GPUs), so the third shard's `rocalCreate` fails cleanly. Compared exit codes before and after the fix using the same repro command.

## Test Result
Before the fix, the shard failure is printed but the process still exits `0`:
```shell
[ERR] {rocalCreate} Failed to init the Rocal context, { MasterGraph } ERROR: HIP Device(%d) out of range2 Could not create the Rocal context exit code: 0
```

After the fix, the same failure is now detected and surfaced as a non-zero exit code:
```shell
[ERR] {rocalCreate} Failed to init the Rocal context, { MasterGraph } ERROR: HIP Device(%d) out of range2 Could not create the Rocal context shard_id: 2 failed with status -1 exit code: 255
```


