### PR TITLE
Docs & Packaging - streamline rocAL dependency documentation and fix CPack metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ Full documentation for rocLibrary is available at [https://rocm.docs.amd.com/pro
 ### Changes
 * Optimized data distribution for the rocJPEG backend to improve multi-threaded decode throughput.
 * LMDB is now an optional dependency. When liblmdb is present at configure time, rocAL builds with Caffe/Caffe2 LMDB reader support; otherwise it builds without it.
+* Packaging - rocAL Debian and RPM runtime packages now use automatic shared-library dependency detection (`dpkg-shlibdeps` / RPM auto-`Requires`) so the packaged `Depends:`/`Requires:` list stays in sync with what `librocal.so` actually links against, instead of a hand-maintained list.
+* Packaging - Added the previously missing Protobuf runtime dependency, and conditional LMDB/FFmpeg/libsndfile/hipFile runtime dependencies, to the rocAL package dependency lists.
+* Docs - README Prerequisites/Libraries section now distinguishes required dependencies from optional, feature-enabling ones (FFMPEG, rocDecode, rocJPEG, libsndfile, Libtar, DLPack, hipFile), and documents that building rocAL_pybind links the Python3 runtime into the core rocAL library.
 * Changes build instructions to omit building of wheels.
 * Adds new public APIs rocalSerialize(), rocalGetSerializedString(), and rocalDeserialize() for serializing and deserializing pipelines.
 * Add support to store the pipeline and introduce template-based serialization functions for different parameter types to convert to protobuf format.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -228,6 +228,67 @@ set(ROCAL_RPM_PACKAGE_LIST     "hip-runtime-amd, openmp-extras-runtime, mivision
 set(ROCAL_DEBIAN_DEV_PACKAGE_LIST  "half, hip-dev, openmp-extras-dev, mivisionx-dev, libprotobuf-dev, libturbojpeg0-dev")
 set(ROCAL_RPM_DEV_PACKAGE_LIST  "half, hip-devel, openmp-extras-devel, mivisionx-devel, protobuf-devel")
 
+# Protobuf is a hard-required core dependency, but its runtime .so was previously only declared
+# in the -dev package lists above, leaving a gap for a minimal `apt install rocal` / `yum install rocal`.
+# The Debian runtime package name is SONAME-versioned and differs by distro/Protobuf release
+# (e.g. libprotobuf23 on Ubuntu 22.04, libprotobuf32t64 on Ubuntu 24.04), so resolve it from the
+# actual library dpkg found on the build machine instead of hardcoding one version.
+set(PROTOBUF_DEBIAN_PACKAGE_NAME "")
+if(EXISTS ${DPKG_EXE} AND PROTOBUF_LIBRARY)
+  execute_process(
+    COMMAND dpkg -S ${PROTOBUF_LIBRARY}
+    RESULT_VARIABLE PROTOBUF_DPKG_RESULT
+    OUTPUT_VARIABLE PROTOBUF_DPKG_OUTPUT
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_QUIET
+  )
+  if(PROTOBUF_DPKG_RESULT EQUAL "0")
+    string(REGEX MATCH "^[^:]+" PROTOBUF_DEBIAN_PACKAGE_NAME "${PROTOBUF_DPKG_OUTPUT}")
+  endif()
+endif()
+if(NOT PROTOBUF_DEBIAN_PACKAGE_NAME)
+  # Fall back to the common recent SONAME package names as apt alternatives if dpkg lookup fails
+  # (e.g. cross-compiling, or building on a non-Debian-based system).
+  set(PROTOBUF_DEBIAN_PACKAGE_NAME "libprotobuf32t64 | libprotobuf32 | libprotobuf23")
+endif()
+set(ROCAL_DEBIAN_PACKAGE_LIST  "${ROCAL_DEBIAN_PACKAGE_LIST}, ${PROTOBUF_DEBIAN_PACKAGE_NAME}")
+# RPM Requires: is conventionally unversioned (matches the existing protobuf-devel dev dependency).
+set(ROCAL_RPM_PACKAGE_LIST     "${ROCAL_RPM_PACKAGE_LIST}, protobuf")
+
+# Conditionally declare optional runtime dependencies that were actually found and linked into
+# librocal.so at build time -- these mirror the "optional / feature-gated" libraries documented
+# in README.md. This list is a fallback safety net; CPACK_DEBIAN_PACKAGE_SHLIBDEPS / RPM
+# auto-Requires (enabled below) should derive the same set automatically from the real NEEDED
+# entries, but is kept here in case shlibdeps/autoreq isn't reliable in a given packaging environment.
+if(LMDB_FOUND)
+  set(ROCAL_DEBIAN_PACKAGE_LIST  "${ROCAL_DEBIAN_PACKAGE_LIST}, liblmdb0")
+  set(ROCAL_RPM_PACKAGE_LIST     "${ROCAL_RPM_PACKAGE_LIST}, lmdb-libs")
+endif()
+if(FFMPEG_FOUND)
+  # The ffmpeg package itself depends on the matching libavcodec/libavformat/libavutil/libswscale
+  # runtime packages on both Debian and RPM-based distros, so depending on it is more portable
+  # than hardcoding the individual SONAME-versioned library package names.
+  set(ROCAL_DEBIAN_PACKAGE_LIST  "${ROCAL_DEBIAN_PACKAGE_LIST}, ffmpeg")
+  set(ROCAL_RPM_PACKAGE_LIST     "${ROCAL_RPM_PACKAGE_LIST}, ffmpeg")
+endif()
+if(SNDFILE_FOUND)
+  set(ROCAL_DEBIAN_PACKAGE_LIST  "${ROCAL_DEBIAN_PACKAGE_LIST}, libsndfile1")
+  set(ROCAL_RPM_PACKAGE_LIST     "${ROCAL_RPM_PACKAGE_LIST}, libsndfile")
+endif()
+if(hipFile_FOUND)
+  # Package name is provided by ROCm; verify against the actual component name for each target
+  # distro before relying on this in production packaging.
+  set(ROCAL_DEBIAN_PACKAGE_LIST  "${ROCAL_DEBIAN_PACKAGE_LIST}, hipfile")
+  set(ROCAL_RPM_PACKAGE_LIST     "${ROCAL_RPM_PACKAGE_LIST}, hipfile")
+endif()
+if(LIBTAR_FOUND)
+  # No standard Debian/RPM distro package exists for libtar (see README -- it's built from
+  # source per the Dockerfiles), so there's no runtime package name to depend on here. This is
+  # also why dpkg-shlibdeps/rpmbuild auto-Requires can't resolve it either: it has no owning
+  # package. Documented as a known limitation rather than guessed.
+  message("-- ${Yellow}NOTE: rocAL linked against libtar (WebDataset support), but no distro package exists to declare as a runtime dependency -- ensure libtar is installed from source wherever rocal is deployed${ColourReset}")
+endif()
+
 # Add OS specific dependencies
 if (EXISTS "/etc/os-release")
   file(READ "/etc/os-release" OS_RELEASE)
@@ -262,9 +323,18 @@ endif()
 set(CPACK_PACKAGING_INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX})
 set(CPACK_DEBIAN_PACKAGE_HOMEPAGE ${CPACK_PACKAGE_HOMEPAGE})
 set(CPACK_RPM_PACKAGE_URL ${CPACK_PACKAGE_HOMEPAGE})
-set(CPACK_RPM_PACKAGE_AUTOREQPROV "no")
+# Turn on automatic shared-library dependency detection so the packaged Depends:/Requires: list
+# stays in sync with whatever actually got linked into librocal.so, instead of relying solely on
+# the hand-maintained ROCAL_DEBIAN_PACKAGE_LIST / ROCAL_RPM_PACKAGE_LIST above. dpkg-shlibdeps /
+# rpmbuild's auto-Requires derive real, correctly-versioned dependencies straight from the
+# binary's NEEDED entries, which is what actually closes the packaging-vs-linkage gap.
+set(CPACK_RPM_PACKAGE_AUTOREQPROV "yes")
+set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
 # Debian package - COMPONENT
 set(CPACK_DEB_COMPONENT_INSTALL ON)
+set(CPACK_DEBIAN_RUNTIME_PACKAGE_SHLIBDEPS ON)
+set(CPACK_DEBIAN_DEV_PACKAGE_SHLIBDEPS ON)
+set(CPACK_DEBIAN_ASAN_PACKAGE_SHLIBDEPS ON)
 set(CPACK_DEBIAN_RUNTIME_PACKAGE_NAME "${PROJECT_NAME}")
 set(CPACK_DEBIAN_RUNTIME_PACKAGE_DEPENDS "rocm-core, ${ROCAL_DEBIAN_PACKAGE_LIST}")
 set(CPACK_DEBIAN_DEV_PACKAGE_NAME "${PROJECT_NAME}-dev")

--- a/README.md
+++ b/README.md
@@ -82,26 +82,38 @@ rocAL can be currently used to perform the following operations either with rand
 ### Libraries
 See [installation instructions](#installation-instructions) for more details and instructions on the prerequisite libraries.
 
+#### Required
 * MIVisionX (note different installation instructions for package and source)
 * CMake (Version `3.10` or later)
 * Google Protobuf (Version `3.12.4` or later)
 * TurboJPEG (Version `2.0` or later)
 * Python3 and Python3 PIP
 * Python3 Wheel
-* LMDB Library (Optional, needed only for Caffe/Caffe2 LMDB reader support)
-* FFMPEG
 * pkg-config
 * PyBind11
 * RapidJSON
 
-Additional required libraries for  source install only:
+Additional required libraries for source install only:
 * rocDecode test package
 
 Additional required libraries for package install only (for source install, these are provided by ROCm `7.13` or later):
 * HIP
 * Half-precision floating-point library (Version `1.12.0` or higher)
-* rocDecode
-* rocJPEG
+
+#### Optional (feature-enabling)
+These libraries are not required to build rocAL. If a library below isn't found at build/configure time, the corresponding feature is simply disabled and the rest of rocAL builds and works normally.
+
+* LMDB Library (Optional, needed only for Caffe/Caffe2 LMDB reader support)
+* FFMPEG (Optional, needed only for software video decode support)
+* rocDecode (Optional, needed only for hardware-accelerated video decode; falls back to software decode via FFMPEG if absent)
+* rocJPEG (Optional, needed only for hardware-accelerated JPEG decode; falls back to TurboJPEG if absent)
+* libsndfile (Optional, needed only for audio pipeline support; also requires MIVisionX `vx_rpp` version `3.1.0` or later)
+* Libtar (Optional, needed only for WebDataset reader support)
+* DLPack (Optional, pybind-only, enables zero-copy tensor interop with TensorFlow/JAX/generic frameworks)
+* hipFile (Optional, HIP backend only, enables GPU Direct Storage I/O for the numpy reader; even when installed, it is disabled at runtime unless `ROCAL_USE_HIPFILE=1` is set)
+
+> [!NOTE]
+> * Building the Python bindings (`rocAL_pybind`) links the system Python3 runtime library directly into the core `librocal.so`, not just into the separate pybind module. If you only need the C++ API, be aware that `librocal.so` will still depend on `libpython3.x` whenever Python3/PyBind11 are found at build time.
 
 > [!IMPORTANT]
 > * Required compiler support
@@ -156,15 +168,6 @@ Follow the [ROCm install guide](https://rocm.docs.amd.com/en/latest/install/rocm
   ```shell
   sudo apt install python3-wheel
   ```
-* [LMDB Library](http://www.lmdb.tech/doc/) - **Optional**: needed only for Caffe/Caffe2 LMDB reader support
-  ```shell
-  sudo apt install liblmdb-dev
-  ```
-
-* [FFMPEG](https://www.ffmpeg.org)
-  ```shell
-  sudo apt install ffmpeg libavcodec-dev libavformat-dev libavutil-dev libswscale-dev
-  ```
 
 Required manual installs:
 * [PyBind11](https://github.com/pybind/pybind11) - Manual install
@@ -175,10 +178,44 @@ Required manual installs:
   * Source: `https://github.com/Tencent/rapidjson.git`
   * Tag: `master`
 
+### Install optional prerequisites (feature-enabling)
+None of the libraries below are required to build rocAL. Install only the ones needed for the optional features you want to use; if a library isn't found at configure time, CMake simply disables the corresponding feature and the rest of the build proceeds normally.
+
+* [LMDB Library](http://www.lmdb.tech/doc/) - needed only for Caffe/Caffe2 LMDB reader support
+  ```shell
+  sudo apt install liblmdb-dev
+  ```
+
+* [FFMPEG](https://www.ffmpeg.org) - needed only for software video decode support
+  ```shell
+  sudo apt install ffmpeg libavcodec-dev libavformat-dev libavutil-dev libswscale-dev
+  ```
+
+* [libsndfile](https://github.com/libsndfile/libsndfile) - Version [1.0.31](https://github.com/libsndfile/libsndfile/releases/tag/1.0.31) or later - needed only for audio pipeline support (also requires MIVisionX `vx_rpp` version `3.1.0` or later)
+  ```shell
+  sudo apt install libsndfile1-dev
+  ```
+
+* [Libtar](https://repo.or.cz/libtar.git) - needed only for WebDataset reader support
+  > [!NOTE]
+  > Libtar has no standard Ubuntu/distribution package and must be built from source.
+  ```shell
+  git clone -b v1.2.20 https://repo.or.cz/libtar.git && cd libtar
+  autoreconf --force --install && CFLAGS="-fPIC" ./configure
+  make -j$(nproc) && sudo make install
+  ```
+
+* [DLPack](https://github.com/dmlc/dlpack) - pybind-only, enables zero-copy tensor interop with TensorFlow/JAX/generic frameworks
+  ```shell
+  sudo apt install libdlpack-dev
+  ```
+
+* hipFile - HIP backend only, enables GPU Direct Storage I/O for the numpy reader (provided by ROCm; even when installed, this feature stays off at runtime unless `ROCAL_USE_HIPFILE=1` is set)
+
 ### Package install
 Available for **ROCm `7.2.x` and below**.
 
-#### Install the additional prerequisite libraries:
+#### Install the additional required prerequisite libraries:
 * HIP
   ```shell
   sudo apt install hip-dev
@@ -193,12 +230,14 @@ Available for **ROCm `7.2.x` and below**.
   ```shell
   sudo apt install half
   ```
-* rocDecode
+
+#### Install the additional optional prerequisite libraries (hardware-accelerated decode):
+* rocDecode - needed only for hardware-accelerated video decode; falls back to FFMPEG software decode if absent
   ```shell
   sudo apt install rocdecode-dev
   ```
 
-* [rocJPEG](https://github.com/ROCm/rocJPEG)
+* [rocJPEG](https://github.com/ROCm/rocJPEG) - needed only for hardware-accelerated JPEG decode; falls back to TurboJPEG if absent
   ```shell
   sudo apt install rocjpeg-dev
   ```

--- a/cmake/FindFFmpeg.cmake
+++ b/cmake/FindFFmpeg.cmake
@@ -189,3 +189,5 @@ else()
     endif()
   endif()
 endif()
+
+set(FFMPEG_FOUND ${FFMPEG_FOUND} CACHE INTERNAL "")

--- a/rocAL/CMakeLists.txt
+++ b/rocAL/CMakeLists.txt
@@ -75,6 +75,7 @@ if(NOT hipFile_FOUND)
          set(hipFile_FOUND TRUE)
      endif()
  endif()
+set(hipFile_FOUND ${hipFile_FOUND} CACHE INTERNAL "")
 
 # HIP Backend
 if(GPU_SUPPORT AND "${BACKEND}" STREQUAL "HIP")


### PR DESCRIPTION
## Motivation
Progress to issue #348 

The issue's `readelf -d`/`ldd` dumps didn't match either the README's documented prerequisites or the current build's real `NEEDED` list. Auditing the CMake `find_package`/`BUILD_ROCAL` gating logic showed:
- FFMPEG, rocDecode, and rocJPEG were documented as required, but CMake only disables the corresponding feature if they're missing - the build succeeds without them.
- libsndfile, libtar, DLPack, and hipFile are all real optional dependencies that were never documented at all.
- Building `rocAL_pybind` links the system Python3 runtime into the **core** `librocal.so` target itself (not just the pybind module), which is why `libpython3.12.so` shows up in the library's `NEEDED` list even for users who only care about the C++ API.
- The packaged `.deb`/`.rpm` `Depends:`/`Requires:` lists were hand-maintained strings in `CMakeLists.txt` that had drifted from actual linkage: Protobuf's runtime `.so` (a hard-required dependency) was only declared in the `-dev` package lists, and LMDB/FFmpeg/libsndfile/hipFile were never declared even when found and linked at build time.
- `FFMPEG_FOUND` and `hipFile_FOUND` were never cached as `CACHE INTERNAL`, so the root `CMakeLists.txt` couldn't see them after `add_subdirectory(rocAL)` to drive any conditional packaging logic.
- OpenCV appears in the issue's dump (~50 `libopencv_*` entries) but is not `find_package`'d or used anywhere in the current `rocAL/rocAL/{include,source}` tree (only a stale comment in `turbo_jpeg_decoder.cpp`) — confirmed via `readelf -d` that the current build has zero OpenCV entries, so the issue's dump was captured against an older build/config. Left as a follow-up to clean up the Dockerfiles, which still build OpenCV from source unnecessarily.

## Technical Details
- `README.md`: split the "Libraries" prerequisites into **Required** and **Optional (feature-enabling)** sections; moved FFMPEG/rocDecode/rocJPEG into Optional; added libsndfile, Libtar (with from-source build steps, since no distro package exists), DLPack, and hipFile, none of which were previously documented; added a note about the pybind-into-core Python3 linkage; mirrored the same required/optional split in the "Install prerequisites" and "Package install" sections.
- `cmake/FindFFmpeg.cmake`: added `set(FFMPEG_FOUND ${FFMPEG_FOUND} CACHE INTERNAL "")` at the end of the module, matching the pattern already used by `FindLMDB.cmake`/`FindSndFile.cmake`/`FindLibTar.cmake`, so the root `CMakeLists.txt` can see whether FFmpeg was actually linked.
- `rocAL/CMakeLists.txt`: added the equivalent `set(hipFile_FOUND ${hipFile_FOUND} CACHE INTERNAL "")` right after the `find_package(hipFile CONFIG QUIET)` / legacy `hipfile` fallback block.
- `CMakeLists.txt` (root):
  - Enabled automatic shared-library dependency detection: `CPACK_DEBIAN_PACKAGE_SHLIBDEPS` (+ per-component `CPACK_DEBIAN_RUNTIME_PACKAGE_SHLIBDEPS`/`_DEV_`/`_ASAN_`) and flipped `CPACK_RPM_PACKAGE_AUTOREQPROV` from `"no"` to `"yes"`, so `dpkg-shlibdeps`/ rpmbuild's auto-`Requires:` derive the real, versioned dependency list from `librocal.so`'s actual `NEEDED` entries going forward.
  - Added Protobuf's runtime package to `ROCAL_DEBIAN_PACKAGE_LIST`/`ROCAL_RPM_PACKAGE_LIST`, resolved dynamically via `dpkg -S` against the actual linked `.so` (falling back to a versioned alternation across Ubuntu 22.04/24.04 SONAMEs if that lookup fails, e.g. a from-source Protobuf build).
  - Conditionally appended LMDB/FFmpeg/libsndfile/hipFile package names guarded by their respective `_FOUND` variables, as a fallback safety net in case shlibdeps/autoreq isn't reliable in a given CI/packaging environment.
  - Added a configure-time diagnostic message for libtar, since no Debian/RPM distro package exists to declare it as a dependency on.

Affected files: `README.md`, `CMakeLists.txt`, `cmake/FindFFmpeg.cmake`,
`rocAL/CMakeLists.txt`.

## Test Plan
Reconfigured the existing HIP-backend build and built the actual `.deb`
packages to confirm the packaging metadata reflects real linkage:

```bash
cd build
cmake ..
cpack -G DEB
dpkg-deb -f rocal_2.5.0-local_amd64.deb Depends
readelf -d lib/librocal.so.2.5.0 | grep NEEDED
```

## Test Result
Before fix: `FFMPEG_FOUND`/`hipFile_FOUND` were invisible to the root `CMakeLists.txt`, so `ffmpeg`/`hipfile` never appeared in the DEB Depends: list despite being linked into `librocal.so`; Protobuf's runtime `.so` had no runtime package declared at all.

After fix: `cmake ..` configure log now shows `ffmpeg, libsndfile1, hipfile` present in the printed `AMD ROCm rocAL DEB RunTime Package` line, and the generated `rocal_2.5.0-local_amd64.deb`'s Depends: field includes both the manual fallback entries and automatically-detected, correctly-versioned entries derived by `dpkg-shlibdeps`, including `libavcodec60 (>= 7:6.0), liblmdb0 (>= 0.9.7), libprotobuf32t64 (>= 3.21.12), libsndfile1 (>= 1.0.20)`, and `libpython3.12t64 (>= 3.12.1)` (the pybind-into-core-library finding) — all of which cross-check against the real `NEEDED` entries from readelf -d. RPM Requires: auto-detection was not locally verifiable (`rpmbuild` is not installed in this environment) and should be confirmed in a RHEL/SLES-based CI job before merge.